### PR TITLE
fix: griser les couches non visibles dans le gestionnaire de couche

### DIFF
--- a/src/features/reports/report.css
+++ b/src/features/reports/report.css
@@ -156,3 +156,7 @@
     width: 100%;
     margin-left: 10px;
 }
+
+.outOfRange .GPlayerName {
+    color: #aaa;
+}

--- a/src/hooks/navigation/layers/useGetReportsLayer.tsx
+++ b/src/hooks/navigation/layers/useGetReportsLayer.tsx
@@ -49,21 +49,15 @@ function useGetReportsLayer(communityId: number) {
     }, [communityId, queryClient, addAlertMessage, setReports]);
 
     useEffect(() => {
-        reports.forEach((report: CommunityReport) => {
-            const mainFeature = reportLayer
-                ?.getSource()
-                ?.getFeatures()
-                ?.find((f) => f.get("reportData").id === report.id && f.get("main"));
-            if (mainFeature) {
-                reportLayer?.getSource()?.removeFeature(mainFeature);
-            }
+        const features = reports.map((report: CommunityReport) => {
             const mainFeatData = {
                 type: "Point" as SketchType,
                 geometry: report.geometry,
             };
-            const feature = getFeaturePoint(report, mainFeatData, true);
-            reportLayer?.getSource()?.addFeature(feature);
+            return getFeaturePoint(report, mainFeatData, true);
         });
+        reportLayer?.getSource()?.clear();
+        reportLayer?.getSource()?.addFeatures(features.flat());
     }, [map, reports, reportLayer]);
 
     return reportLayer;

--- a/src/hooks/navigation/layers/useGetWFSLayer.tsx
+++ b/src/hooks/navigation/layers/useGetWFSLayer.tsx
@@ -9,9 +9,12 @@ import GeoJSON from "ol/format/GeoJSON";
 import { bbox as bboxStrategy } from "ol/loadingstrategy";
 import { CommunityGeoservice, StatusMessage } from "@/constants/communities/types";
 import { useQueryClient } from "@tanstack/react-query";
+import { useMapStore } from "@/store";
 
 function useGetWFSLayer(geoservice: CommunityGeoservice) {
     const { addAlertMessage } = useCommunityStore();
+    const { map } = useMapStore();
+
     const queryClient = useQueryClient();
 
     const wfsLayer = useMemo(() => {
@@ -55,10 +58,17 @@ function useGetWFSLayer(geoservice: CommunityGeoservice) {
         wfsLayer.set("description", geoservice.description);
         wfsLayer.setMinZoom(geoservice.minZoom);
         wfsLayer.setMaxZoom(geoservice.maxZoom);
+        if (map) {
+            const mapView = map.getView();
+            const minResolution = mapView?.getResolutionForZoom(geoservice.maxZoom);
+            const maxResolution = mapView?.getResolutionForZoom(geoservice.minZoom);
+            wfsLayer.setMinResolution(minResolution);
+            wfsLayer.setMaxResolution(maxResolution);
+        }
         const extent = geoservice.extent.split(",")?.map((extent) => parseFloat(extent));
         wfsLayer.setExtent(transformExtent(extent, "EPSG:4326", "EPSG:3857"));
         return wfsLayer;
-    }, [geoservice, queryClient, addAlertMessage]);
+    }, [geoservice, queryClient, map, addAlertMessage]);
 
     return wfsLayer;
 }

--- a/src/hooks/navigation/layers/useGetWMSLayer.tsx
+++ b/src/hooks/navigation/layers/useGetWMSLayer.tsx
@@ -5,6 +5,7 @@ import { useCommunityStore } from "@/store/useCommunityStore";
 import useGetCapabilitiesWMS from "../capabilities/useGetCapabilitiesWMS";
 import { transformExtent } from "ol/proj";
 import { CommunityGeoservice, StatusMessage } from "@/constants/communities/types";
+import { useMapStore } from "@/store";
 
 type CapabilityLayer = {
     Name: string;
@@ -14,6 +15,8 @@ function useGetWMSLayer(geoservice: CommunityGeoservice) {
     const { data: capabilities, error } = useGetCapabilitiesWMS(geoservice);
 
     const { addAlertMessage } = useCommunityStore();
+    const { map } = useMapStore();
+
     useEffect(() => {
         if (error) {
             addAlertMessage(StatusMessage.error, `Erreur dans le chargement de la couche ${geoservice.title}`);
@@ -54,10 +57,17 @@ function useGetWMSLayer(geoservice: CommunityGeoservice) {
         wmsLayer.set("description", geoservice.description);
         wmsLayer.setMinZoom(geoservice.minZoom);
         wmsLayer.setMaxZoom(geoservice.maxZoom);
+        if (map) {
+            const mapView = map.getView();
+            const minResolution = mapView?.getResolutionForZoom(geoservice.maxZoom);
+            const maxResolution = mapView?.getResolutionForZoom(geoservice.minZoom);
+            wmsLayer.setMinResolution(minResolution);
+            wmsLayer.setMaxResolution(maxResolution);
+        }
         const extent = geoservice.extent.split(",")?.map((extent) => parseFloat(extent));
         wmsLayer.setExtent(transformExtent(extent, "EPSG:4326", "EPSG:3857"));
         return wmsLayer;
-    }, [capabilities, geoservice]);
+    }, [capabilities, geoservice, map]);
 
     return wmsLayer;
 }

--- a/src/hooks/navigation/layers/useGetWMTSLayer.tsx
+++ b/src/hooks/navigation/layers/useGetWMTSLayer.tsx
@@ -6,11 +6,13 @@ import useGetCapabilitiesWMTS from "@/hooks/navigation/capabilities/useGetCapabi
 import { useCommunityStore } from "@/store/useCommunityStore";
 import { transformExtent } from "ol/proj";
 import { CommunityGeoservice, StatusMessage } from "@/constants/communities/types";
+import { useMapStore } from "@/store";
 
 function useGetWMTSLayer(geoservice: CommunityGeoservice) {
     const { data: capabilities, error } = useGetCapabilitiesWMTS(geoservice);
 
     const { addAlertMessage } = useCommunityStore();
+    const { map } = useMapStore();
     useEffect(() => {
         if (error) {
             addAlertMessage(StatusMessage.error, `Erreur dans le chargement de la couche ${geoservice.title}`);
@@ -43,10 +45,19 @@ function useGetWMTSLayer(geoservice: CommunityGeoservice) {
         wmtsLayer.set("description", geoservice.description);
         wmtsLayer.setMinZoom(geoservice.minZoom);
         wmtsLayer.setMaxZoom(geoservice.maxZoom);
+
+        if (map) {
+            const mapView = map.getView();
+            const minResolution = mapView?.getResolutionForZoom(geoservice.maxZoom);
+            const maxResolution = mapView?.getResolutionForZoom(geoservice.minZoom);
+            wmtsLayer.setMinResolution(minResolution);
+            wmtsLayer.setMaxResolution(maxResolution);
+        }
+
         const extent = geoservice.extent.split(",")?.map((extent) => parseFloat(extent));
         wmtsLayer.setExtent(transformExtent(extent, "EPSG:4326", "EPSG:3857"));
         return wmtsLayer;
-    }, [capabilities, geoservice]);
+    }, [capabilities, geoservice, map]);
 
     return wmtsLayer;
 }


### PR DESCRIPTION
Griser les couches invisibles dans le gestionnaire de couche: 

![image](https://github.com/user-attachments/assets/c8e1d89e-e049-4048-8d36-6728daaa0565)

Rendre les couches visibles en noir dans le gestionnaire de couche:

![image](https://github.com/user-attachments/assets/355e1f38-007e-46fc-bd35-cdefd5072eca)

Issue concernée : #33 

