### PR TITLE
feat: création de signalement - clic sur la carte avant d'ouvrir le volet latéral

### DIFF
--- a/src/components/DrawerComponent.tsx
+++ b/src/components/DrawerComponent.tsx
@@ -9,10 +9,11 @@ interface Props {
     anchor: AnchorType;
     isOpen: boolean;
     children: JSX.Element;
+    create: boolean;
     onClose: () => void;
 }
 
-const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, onClose }) => {
+const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, create, onClose }) => {
     const mapToolbarHeader = document.getElementById("map-toolbar-header");
     const headerHeight = mapToolbarHeader?.clientHeight || 0;
     return (
@@ -26,7 +27,7 @@ const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, onClose })
                 sx={{ "& .MuiDrawer-paper,.MuiBackdrop-root": { height: `calc(100vh - ${headerHeight}px)`, top: headerHeight, overflow: "unset" } }}
             >
                 <div className="drawer-close">
-                    <Button iconId="ri-close-line" onClick={onClose} priority="tertiary no outline" title="Fermer" />
+                    {!create && <Button iconId="ri-close-line" onClick={onClose} priority="tertiary no outline" title="Fermer" />}
                 </div>
                 <div className="drawer-content" style={{ height: `calc(100vh - 40px - ${headerHeight}px)`, overflow: "auto" }}>
                     {children}

--- a/src/constants/reports/types.tsx
+++ b/src/constants/reports/types.tsx
@@ -18,6 +18,7 @@ export enum SketchFeatureType {
 }
 export type ParamsReport = {
     feature: Feature;
+    geomType: string;
     closeFunc: () => void;
 };
 

--- a/src/features/navigation/controls/drawingControl.ts
+++ b/src/features/navigation/controls/drawingControl.ts
@@ -33,7 +33,7 @@ const drawingControl = new Drawing({
         points: true,
         lines: true,
         polygons: true,
-        holes: true,
+        holes: false,
         text: true,
         remove: true,
         display: true,

--- a/src/features/reports/ConfirmCancelModal.tsx
+++ b/src/features/reports/ConfirmCancelModal.tsx
@@ -1,0 +1,30 @@
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+
+interface Props {
+    modal: ReturnType<typeof createModal>;
+    onClose: () => void;
+}
+
+const ConfirmCancelModal: React.FC<Props> = ({ modal, onClose }) => {
+    return (
+        <modal.Component
+            title=" Confirmation"
+            iconId="fr-icon-info-fill"
+            buttons={[
+                {
+                    iconId: "ri-close-line",
+                    children: "Non, continuer la saisie",
+                },
+                {
+                    iconId: "ri-check-line",
+                    onClick: onClose,
+                    children: "Oui, annuler",
+                },
+            ]}
+        >
+            <p>En annulant la création de ce signalement vous supprimerez les éventuels documents et croquis associés. Voulez-vous continuer ?</p>
+        </modal.Component>
+    );
+};
+
+export default ConfirmCancelModal;

--- a/src/features/reports/CreateReport.tsx
+++ b/src/features/reports/CreateReport.tsx
@@ -61,7 +61,7 @@ const CreateReport: React.FC<Props> = ({ handleCloseDrawer }) => {
         handleCloseDrawer();
     };
 
-    return <ReportForm handleSubmit={handleSubmit} />;
+    return <ReportForm handleSubmit={handleSubmit} handleClose={handleCloseDrawer} />;
 };
 
 export default CreateReport;

--- a/src/features/reports/DrawingForm.tsx
+++ b/src/features/reports/DrawingForm.tsx
@@ -32,9 +32,9 @@ const DrawingForm: React.FC<Props> = ({ features, selectedReport, clickedTool, s
 
     const mainFeature = useMemo(() => {
         if (selectedReport) {
-            return features.find((f) => f.get("reportData") && f.get("main"));
+            return features.find((f) => f.get("reportData") && f.get("main") && !f.get("new"));
         }
-        return features.find((f) => (f.get("reportData") && f.get("main")) || f.get("main"));
+        return features.find((f) => f.get("new") && f.get("main"));
     }, [features, selectedReport]);
 
     const sketchFeatures = useMemo(() => {

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -1,21 +1,24 @@
 import DrawerComponent from "@/components/DrawerComponent";
-import { CommunityReport } from "@/constants/reports/types";
+import { CommunityReport, ParamsReport, toolNames } from "@/constants/reports/types";
 import { useCommunityStore, useMapStore } from "@/store";
-import { Feature } from "ol";
+import { Feature, MapBrowserEvent } from "ol";
 import { Style } from "ol/style";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import ShowReport from "./ShowReport";
 import CreateReport from "./CreateReport";
+import Layer from "ol/layer/Layer";
+import VectorSource from "ol/source/Vector";
 
 const ReportDrawer = () => {
     const [drawerOpened, setDrawerOpened] = useState<boolean>(false);
     const [selectedReport, setSelectedReport] = useState<CommunityReport | undefined>(undefined);
 
     const { reports } = useCommunityStore();
-    const { map, clickedFeature, setClickedFeature } = useMapStore();
+    const { map } = useMapStore();
 
-    useEffect(() => {
-        map?.on("singleclick", function (evt) {
+    const handleSingleClick = useCallback(
+        (evt: MapBrowserEvent<PointerEvent>) => {
+            if (drawerOpened) return;
             const features: { feature: Feature; zIndex: number }[] = [];
 
             map?.forEachFeatureAtPixel(evt.pixel, function (feature) {
@@ -39,13 +42,16 @@ const ReportDrawer = () => {
             });
             const topFeature = features[0];
             if (topFeature) {
-                if (!topFeature.feature.get("new")) {
+                if (topFeature.feature.get("reportData")) {
                     setSelectedReport(topFeature.feature.get("reportData"));
                 }
-                setClickedFeature(topFeature.feature);
             }
-        });
-        map?.on("pointermove", function (evt) {
+        },
+        [map, drawerOpened]
+    );
+
+    const handlePointerMove = useCallback(
+        (evt: MapBrowserEvent<PointerEvent>) => {
             const features = map?.getFeaturesAtPixel(evt.pixel);
             const feature = features?.find((f) => f.get("reportData") || f.get("new"));
 
@@ -66,43 +72,80 @@ const ReportDrawer = () => {
                 targetElement.style.cursor = "";
                 return;
             }
-        });
+        },
+        [map]
+    );
+
+    useEffect(() => {
+        map?.on("singleclick", handleSingleClick);
+        map?.on("pointermove", handlePointerMove);
         if (selectedReport) {
             setSelectedReport(reports.find((r) => r.id === selectedReport.id));
         }
-    }, [map, reports, selectedReport, setClickedFeature]);
+        return () => {
+            map?.un("singleclick", handleSingleClick);
+            map?.un("pointermove", handlePointerMove);
+        };
+    }, [map, reports, selectedReport, drawerOpened, handleSingleClick, handlePointerMove]);
+
+    const handleDrawingAdd = useCallback(
+        (e: Event) => {
+            const customEvent = e as CustomEvent<ParamsReport>;
+            customEvent.detail.feature.set("new", true);
+            if (customEvent.detail.geomType === "Point" && !drawerOpened) {
+                customEvent.detail.feature.set("main", true);
+                const toolButton = document.querySelector(`button[id*="${toolNames.point}"]`) as HTMLButtonElement | null;
+
+                if (toolButton && toolButton.classList.contains("drawing-tool-active")) {
+                    toolButton.click();
+                }
+                setDrawerOpened(true);
+            }
+        },
+        [drawerOpened, setDrawerOpened]
+    );
 
     useEffect(() => {
-        const createReportButton = document.querySelector(`button[id*="GPshowDrawingPicto"]`) as HTMLButtonElement | null;
+        if (!drawerOpened) {
+            document.addEventListener("create-report-event", handleDrawingAdd);
+            const createReportButton = document.querySelector(`button[id*="GPshowDrawingPicto"]`) as HTMLButtonElement | null;
 
-        if (createReportButton) {
-            createReportButton.onclick = () => {
-                if (createReportButton.getAttribute("aria-pressed") === "true") {
+            if (createReportButton) {
+                if (!drawerOpened) {
+                    if (createReportButton.getAttribute("aria-pressed") === "true") {
+                        createReportButton.click();
+                    }
+                }
+
+                if (selectedReport && !drawerOpened) {
                     setDrawerOpened(true);
-                }
-            };
-            if (clickedFeature) {
-                setDrawerOpened(true);
-                if (createReportButton.getAttribute("aria-pressed") === "false") {
-                    createReportButton.click();
+                    if (createReportButton.getAttribute("aria-pressed") === "false") {
+                        createReportButton.click();
+                    }
                 }
             }
-            if (!drawerOpened) {
-                if (createReportButton.getAttribute("aria-pressed") === "true") {
-                    createReportButton.click();
-                }
-            }
+        } else {
+            document.removeEventListener("create-report-event", handleDrawingAdd);
         }
-    }, [clickedFeature, drawerOpened]);
+
+        return () => {
+            document.removeEventListener("create-report-event", handleDrawingAdd);
+        };
+    }, [drawerOpened, selectedReport, handleDrawingAdd]);
 
     const handleCloseDrawer = () => {
+        if (!selectedReport) {
+            const drawingLayer = map?.getAllLayers().find((layer: Layer & { gpResultLayerId?: string }) => layer.gpResultLayerId === "drawing");
+            const drawingSource = drawingLayer?.getSource() as VectorSource;
+            const newFeatures = drawingSource?.getFeatures()?.filter((f) => f.get("new")) || [];
+            drawingSource.removeFeatures(newFeatures);
+        }
         setSelectedReport(undefined);
         setDrawerOpened(false);
-        setClickedFeature(null);
     };
 
     return (
-        <DrawerComponent anchor="left" isOpen={drawerOpened} onClose={handleCloseDrawer}>
+        <DrawerComponent anchor="left" isOpen={drawerOpened} create={!selectedReport} onClose={handleCloseDrawer}>
             {drawerOpened ? (
                 <>
                     {selectedReport ? (

--- a/src/features/reports/ReportForm.tsx
+++ b/src/features/reports/ReportForm.tsx
@@ -15,6 +15,13 @@ import DrawingForm from "./DrawingForm";
 import { Feature } from "ol";
 import CenterFeature from "./CenterFeature";
 import { reportTools } from "@/constants/reports/utils";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import ConfirmCancelModal from "./ConfirmCancelModal";
+
+const confirmModal = createModal({
+    id: "confirm-modal",
+    isOpenedByDefault: false,
+});
 
 const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
 const maxSizeMB = 3;
@@ -288,9 +295,14 @@ const ReportForm: React.FC<Props> = ({ selectedReport, handleSubmit, handleDelet
                 </div>
 
                 {!selectedReport ? (
-                    <Button size="large" onClick={onSubmit} className="submit">
-                        Envoyer le signalement
-                    </Button>
+                    <div className="submit">
+                        <Button size="large" onClick={onSubmit}>
+                            Envoyer le signalement
+                        </Button>
+                        <Button nativeButtonProps={confirmModal.buttonProps} priority="tertiary no outline" title="Annuler">
+                            Annuler
+                        </Button>
+                    </div>
                 ) : (
                     <div className="buttons">
                         <Button priority="secondary" onClick={onDelete}>
@@ -304,6 +316,7 @@ const ReportForm: React.FC<Props> = ({ selectedReport, handleSubmit, handleDelet
                 )}
             </div>
             <CenterFeature features={features} />
+            <ConfirmCancelModal modal={confirmModal} onClose={onClose} />
         </>
     );
 };

--- a/src/features/reports/report.css
+++ b/src/features/reports/report.css
@@ -61,6 +61,13 @@
 .report-drawer .submit {
     width: 100%;
     display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.report-drawer .submit button {
+    width: 100%;
+    display: flex;
     justify-content: center;
 }
 

--- a/src/store/useMapStore.ts
+++ b/src/store/useMapStore.ts
@@ -1,20 +1,14 @@
-import { Feature, Map } from "ol";
+import { Map } from "ol";
 import { create } from "zustand";
 
 interface MapStore {
     map: Map | null;
-    clickedFeature: Feature | null;
     setMap: (map: Map | null) => void;
-    setClickedFeature: (feature: Feature | null) => void;
 }
 
 export const useMapStore = create<MapStore>((set) => ({
     map: null,
-    clickedFeature: null,
     setMap: (map) => {
         set({ map });
-    },
-    setClickedFeature: (feature) => {
-        set({ clickedFeature: feature });
     },
 }));


### PR DESCRIPTION
Création de signalement avant d'ouvrir le volet latéral et supprimer le bouton "Fermer" du volet:
![image](https://github.com/user-attachments/assets/0fa9c966-e6b8-4b7b-8da7-400ae383cae0)

Ajouter un bouton "Annuler": 
![image](https://github.com/user-attachments/assets/c73db075-c082-4624-8e5d-95923a2bc693)

Afficher la modale de confirmation avant de fermer le volet:
![image](https://github.com/user-attachments/assets/1b9c6ab9-ec6e-4034-8b37-353192399114)

Issue concernée : #38 
