### PR TITLE
fix: erreur d'importation du fichier kml, gpx et geojson

### DIFF
--- a/src/api/reportsData.ts
+++ b/src/api/reportsData.ts
@@ -4,7 +4,7 @@ import { useUserStore } from "@/store/useUserStore";
 import { CommunityReport, PostReport, reportData, SketchReport, StatusKey } from "@/constants/reports/types";
 import { REPORTS_API_URL } from "@/constants/urls";
 import { transformExtent } from "ol/proj";
-import { Extent } from "ol/extent";
+import { Extent, isEmpty } from "ol/extent";
 import { axiosApi } from ".";
 
 export const isDigital = (value: string): boolean => {
@@ -29,11 +29,11 @@ export const getCommunityReportSketch = (report: reportData) => {
 };
 
 export async function getCommunityReports(communityId: number, extent: Extent): Promise<CommunityReport[] | null> {
+    const boxExtent = transformExtent(extent, "EPSG:3857", "EPSG:4326");
+    if (!isFinite(boxExtent[0]) || isEmpty(boxExtent)) return null;
     const limit = 100;
     const data = [];
-    const res = await axiosApi.get(
-        `${REPORTS_API_URL}?communities=${communityId}` + `&limit=${limit}` + `&box=${transformExtent(extent, "EPSG:3857", "EPSG:4326")}`
-    );
+    const res = await axiosApi.get(`${REPORTS_API_URL}?communities=${communityId}` + `&limit=${limit}` + `&box=${boxExtent}`);
     if (!res.data || (res.status !== 200 && res.status !== 206)) return null;
 
     data.push(...res.data);

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -31,7 +31,7 @@ export const clusterReportPinStyle = (geometry: Geometry | undefined = undefined
 
 export const clusterCircleStyle = (size: number = 0) =>
     new CircleStyle({
-        radius: Math.max(size * 1.5, 15),
+        radius: Math.min(size * 1.5, 30),
         fill: new Fill({
             color: CLUSTER_CIRCLE_COLOR,
         }),

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -21,7 +21,7 @@ import createCrossImg from "../img/reports/marketlist/cross.png";
 import createXImg from "../img/reports/marketlist/x.png";
 import createTriangleImg from "../img/reports/marketlist/triangle.png";
 import createPointImg from "../img/reports/create_point.png";
-import { getCenter } from "ol/extent";
+import { getCenter, isEmpty } from "ol/extent";
 import React from "react";
 
 const wktFormat = new WKT();
@@ -256,6 +256,11 @@ export const handleCenterToFeature = (map: Map | null, feature: Feature) => {
     const geometry: GeometryFeatueParams = feature?.getGeometry() as GeometryFeatueParams;
 
     const featureExtent = geometry?.getExtent() || [];
+    if (!isFinite(featureExtent[0]) || isEmpty(featureExtent)) {
+        throw Error();
+    }
+    const featureCenter = getCenter(featureExtent);
+
     const view = map?.getView();
 
     const size = map?.getSize();
@@ -266,7 +271,7 @@ export const handleCenterToFeature = (map: Map | null, feature: Feature) => {
     if (featureZoom) {
         view?.setZoom(featureZoom);
     }
-    const featureCenter = getCenter(featureExtent);
+
     view?.setCenter(featureCenter);
 };
 

--- a/src/features/reports/forms/ImportSketchFile.tsx
+++ b/src/features/reports/forms/ImportSketchFile.tsx
@@ -7,6 +7,11 @@ import { ChangeEvent, RefObject } from "react";
 
 const inputAccept = ".gpx,.kml,.geojson";
 
+const isFileAccepted = (type: string) => {
+    const fileType = type.toLocaleLowerCase();
+    return fileType.includes("kml") || fileType.includes("gpx") || fileType.includes("geojson");
+};
+
 interface Props {
     inputRef: RefObject<HTMLInputElement | null>;
 }
@@ -21,8 +26,8 @@ const ImportSketchFile: React.FC<Props> = ({ inputRef }) => {
         const files = e.target.files || [];
         Array.from(files).forEach((file) => {
             const splitedFileName = file.name.split(".");
-            const fileType = file.type || file.name.split(".")[splitedFileName.length - 1];
-            if (!inputAccept.includes(fileType)) {
+            const fileType = file.type || splitedFileName[splitedFileName.length - 1];
+            if (!isFileAccepted(fileType)) {
                 addAlertMessage(
                     StatusMessage.error,
                     `Le fichier "${file.name}" ne peut pas être importé. Seuls les formats kml, gpx et geojson sont supportés`

--- a/src/features/reports/forms/SketchList.tsx
+++ b/src/features/reports/forms/SketchList.tsx
@@ -1,8 +1,10 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { StatusMessage } from "@/constants/communities/types";
 import { SketchFeatureType, toolNames } from "@/constants/reports/types";
 import { reportTools } from "@/constants/reports/utils";
 import { selectionCircleStyle } from "@/constants/styles";
 import { getFeatureDiam, handleCenterToFeature, mainMarker, markersStyles, otherMarkers } from "@/constants/utils";
-import { useMapStore, useReportStore } from "@/store";
+import { useCommunityStore, useMapStore, useReportStore } from "@/store";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Drawing from "geopf-extensions-openlayers/src/packages/Controls/Drawing/Drawing";
 import { Feature } from "ol";
@@ -12,12 +14,12 @@ import { Size } from "ol/size";
 import VectorSource from "ol/source/Vector";
 import { Style } from "ol/style";
 import ImageStyle from "ol/style/Image";
-import { useCallback, useEffect, useMemo } from "react";
 
 const hoveredFeatureStyle: { strockWidth: number; imageScale: number | Size } = { strockWidth: 1, imageScale: 1 };
 
 const SketchList = () => {
     const { map } = useMapStore();
+    const { addAlertMessage } = useCommunityStore();
     const { selectedFeatures, isShowReport, setSelectedFeatures } = useReportStore();
 
     const clusterLayer = map?.getAllLayers().find((layer) => layer.get("title") === "Signalements");
@@ -99,6 +101,18 @@ const SketchList = () => {
         feature.changed();
     };
 
+    const handleClickFeature = useCallback(
+        (feature: Feature) => {
+            try {
+                handleCenterToFeature(map, feature);
+            } catch (error) {
+                addAlertMessage(StatusMessage.error, "Impossible d'afficher ce croquis : sa géométrie est vide ou non définie.");
+                console.error(error);
+            }
+        },
+        [map, addAlertMessage]
+    );
+
     return (
         <div className="report-features">
             {isShowReport() && !sketchFeatures.length && <p>Aucun croquis associé</p>}
@@ -130,7 +144,7 @@ const SketchList = () => {
                         onMouseEnter={() => handleHoverFeature(feature, true)}
                         onMouseLeave={() => handleHoverFeature(feature, false)}
                     >
-                        <div className="sketch" onClick={() => handleCenterToFeature(map, feature)}>
+                        <div className="sketch" onClick={() => handleClickFeature(feature)}>
                             <img width={20} height={20} src={icon} alt={text} />
                             <span>{text}</span>
                         </div>

--- a/src/hooks/navigation/layers/useGetReportsLayer.tsx
+++ b/src/hooks/navigation/layers/useGetReportsLayer.tsx
@@ -12,6 +12,7 @@ import { bbox } from "ol/loadingstrategy";
 import { useQueryClient } from "@tanstack/react-query";
 import { transformExtent } from "ol/proj";
 import { useMapStore, useReportStore } from "@/store";
+import { isEmpty } from "ol/extent";
 
 function useGetReportsLayer(communityId: number) {
     const { addAlertMessage } = useCommunityStore();
@@ -23,10 +24,13 @@ function useGetReportsLayer(communityId: number) {
         const reportSource = new VectorSource<Feature<Geometry>>({
             loader: async function (extent) {
                 try {
-                    const queryKey = `GET_REPORTS_communities=${communityId}` + `_limit=20` + `_box=${transformExtent(extent, "EPSG:3857", "EPSG:4326")}`;
+                    const boxExtent = transformExtent(extent, "EPSG:3857", "EPSG:4326");
+                    if (!isFinite(boxExtent[0]) || isEmpty(boxExtent)) return;
+                    const queryKey = `GET_REPORTS_communities=${communityId}` + `_limit=20` + `_box=${boxExtent}`;
                     const reports = await queryClient.fetchQuery({
                         queryKey: [queryKey],
                         queryFn: () => getCommunityReports(communityId, extent),
+                        retry: !isFinite(boxExtent[0]) || isEmpty(boxExtent) ? 0 : 1,
                     });
 
                     if (!reports) {


### PR DESCRIPTION
Fix de tout type de fichier importé.
Ajout d'un message d'erreur sur la concentration d'un croquis à extent infini: 
<img width="811" height="82" alt="image" src="https://github.com/user-attachments/assets/d1fa1848-4aba-4ae0-a167-1e4b7d57431b" />

Ajout de la contrainte de chargement des signalements à extent infini.