### PR TITLE
Feat/filtres url params

### DIFF
--- a/src/components/FilterAndSortReport.tsx
+++ b/src/components/FilterAndSortReport.tsx
@@ -12,7 +12,7 @@ import { Fragment } from "react/jsx-runtime";
 
 interface SelectProps {
     label: string;
-    options: string[];
+    options: string[] | number[];
     name: string;
 }
 type SortableKeys = "opening_date" | "updating_date";
@@ -58,6 +58,8 @@ const transformReportsToTableData = (reports: GetReportData[]) => {
 const FilterAndSortReport = () => {
     const { community } = useCommunityStore();
     const { setFilteredReports } = useReportStore();
+    const [, setSearchParams] = useSearchParams();
+
     const queryKey = `${REPORTS_API_URL}?communities=${community?.id}`;
     const {
         data: reports = [],
@@ -82,8 +84,8 @@ const FilterAndSortReport = () => {
         }
         return [];
     }, [reports]);
+    const limitOptions = [2, 5, 10, 15, 20, 30];
 
-    const [, setSearchParams] = useSearchParams();
     const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         const form = (e.target as HTMLButtonElement).form;
@@ -96,21 +98,19 @@ const FilterAndSortReport = () => {
             department: formData.get("department"),
         };
         const sortBy = sortOptions[parseInt((formData.get("sort") as SortableKeys) || "")];
+        const limitBy = limitOptions[parseInt(formData.get("limit") as string)];
 
         const params = new URLSearchParams();
-        const url =
-            `${REPORTS_API_URL}` +
-            params.set("communities", community?.id.toString() || "") +
-            params.set("fields", "id,status,author,commune,departement,opening_date,updating_date,attributes") +
-            (filterBy.department ? params.set("departements", filterBy.department.toString()) : "") +
-            (filterBy.status ? params.set("status", filterBy.status) : "") +
-            (filterBy.author ? params.set("author", filterBy.author.toString()) : "") +
-            (filterBy.theme ? params.set("attributes", filterBy.theme) : "") +
-            (sortBy ? params.set("sort", sortBy + "asc") : "");
+        params.set("communities", community?.id?.toString() || "");
+        if (limitBy) params.set("limit", limitBy?.toString() || "");
+        if (filterBy.department) params.set("departements", filterBy.department.toString());
+        if (filterBy.status) params.set("status", filterBy.status);
+        if (filterBy.author) params.set("author", filterBy.author.toString());
+        if (filterBy.theme) params.set("attributes", filterBy.theme);
+        if (sortBy) params.set("sort", sortBy);
 
         params.set("page", "1"); // go to initial page (page 1) when totalPage changes
         setSearchParams(params);
-        console.log(filterBy, sortBy, url);
 
         const filtered = reports.filter(
             (report) =>
@@ -121,11 +121,11 @@ const FilterAndSortReport = () => {
         );
 
         if (sortBy) {
-            //DESC
+            //ASC
             filtered.sort((a, b) => {
                 const aValue = a[sortBy] ?? "";
                 const bValue = b[sortBy] ?? "";
-                return new Date(bValue).getTime() - new Date(aValue).getTime();
+                return new Date(aValue).getTime() - new Date(bValue).getTime();
             });
         }
         setFilteredReports(filtered, true);
@@ -157,8 +157,13 @@ const FilterAndSortReport = () => {
 
             <div>
                 <h3>Triage : </h3>
-                <div className="filter">
-                    <SelectComponent name="sort" label="Date" options={sortOptions} />
+                <div className="filter-report__wrapper">
+                    <div className="filter">
+                        <SelectComponent name="sort" label="Date" options={sortOptions} />
+                    </div>
+                    <div className="filter">
+                        <SelectComponent name="limit" label="Limit" options={limitOptions} />
+                    </div>
                 </div>
             </div>
 

--- a/src/components/FilterAndSortReport.tsx
+++ b/src/components/FilterAndSortReport.tsx
@@ -7,6 +7,7 @@ import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/Select";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Fragment } from "react/jsx-runtime";
 
 interface SelectProps {
@@ -82,6 +83,7 @@ const FilterAndSortReport = () => {
         return [];
     }, [reports]);
 
+    const [, setSearchParams] = useSearchParams();
     const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         const form = (e.target as HTMLButtonElement).form;
@@ -95,14 +97,20 @@ const FilterAndSortReport = () => {
         };
         const sortBy = sortOptions[parseInt((formData.get("sort") as SortableKeys) || "")];
 
+        const params = new URLSearchParams();
         const url =
             `${REPORTS_API_URL}` +
-            `?communities=${community?.id}` +
-            (filterBy.department ? `&departements=${filterBy.department}` : "") +
-            (filterBy.status ? `&status=${filterBy.status}` : "") +
-            (filterBy.author ? `&author=${filterBy.author}` : "") +
-            (filterBy.theme ? `&attributes=${filterBy.theme}` : "") +
-            (sortBy ? `&sort=${sortBy}:asc` : "");
+            params.set("communities", community?.id.toString() || "") +
+            params.set("fields", "id,status,author,commune,departement,opening_date,updating_date,attributes") +
+            (filterBy.department ? params.set("departements", filterBy.department.toString()) : "") +
+            (filterBy.status ? params.set("status", filterBy.status) : "") +
+            (filterBy.author ? params.set("author", filterBy.author.toString()) : "") +
+            (filterBy.theme ? params.set("attributes", filterBy.theme) : "") +
+            (sortBy ? params.set("sort", sortBy + "asc") : "");
+
+        params.set("page", "1"); // go to initial page (page 1) when totalPage changes
+        setSearchParams(params);
+        console.log(filterBy, sortBy, url);
 
         const filtered = reports.filter(
             (report) =>
@@ -125,7 +133,6 @@ const FilterAndSortReport = () => {
         if (isLoading) return <div>Chargement des signalements...</div>;
         if (error) return <div>Erreur lors du chargement des signalements.</div>;
         if (filtered.length === 0) return <div>Aucun signalement trouvé.</div>;
-        console.log(filterBy, sortBy, url);
     };
 
     return (

--- a/src/features/reports/table/PaginationReport.tsx
+++ b/src/features/reports/table/PaginationReport.tsx
@@ -16,15 +16,21 @@ const PaginationReport = ({ totalPage, searchParams, setSearchParams }: Paginati
                 <Pagination
                     count={totalPage}
                     defaultPage={Number(searchParams.get("page")) || 1}
-                    getPageLinkProps={(pageNumber: number) => ({
-                        href: `?page=${pageNumber}`,
-                        "aria-label": `Aller à la page ${pageNumber}`,
+                    getPageLinkProps={(pageNumber: number) => {
+                        // Clone current params
+                        const params = new URLSearchParams(searchParams.toString());
+                        // Change only page param
+                        params.set("page", pageNumber.toString());
+                        return {
+                            href: `?page=${pageNumber}+?${params.toString()}`,
+                            "aria-label": `Aller à la page ${pageNumber}`,
 
-                        onClick: (e) => {
-                            e.preventDefault();
-                            setSearchParams({ page: pageNumber.toString() });
-                        },
-                    })}
+                            onClick: (e) => {
+                                e.preventDefault();
+                                setSearchParams(params);
+                            },
+                        };
+                    }}
                     showFirstLast
                 />
             </div>

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -7,6 +7,7 @@ import { useCommunityStore } from "@/store/useCommunityStore";
 import { REPORTS_API_URL } from "@/constants/urls";
 import type { GetReportData } from "@/constants/reports/types";
 import PaginationReport from "./PaginationReport";
+import usePagination from "@/hooks/usePagination";
 
 const transformReportsToTableData = (reports: GetReportData[]) => {
     return reports.map((report) => [
@@ -22,7 +23,6 @@ const TableReport = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const { community } = useCommunityStore();
     const { filteredReports, isFiltered } = useReportStore();
-
     const queryKey = `${REPORTS_API_URL}?communities=${community?.id}`;
     const {
         data: reports,
@@ -33,13 +33,9 @@ const TableReport = () => {
         queryFn: () => (community ? getReports(community.id) : Promise.resolve([])),
         enabled: !!community,
     });
+    const limit = Number(searchParams.get("limit")) || 10;
     const tableData = transformReportsToTableData(filteredReports.length > 0 ? filteredReports : (reports ?? []));
-    const totalPage = Math.ceil(tableData.length / 10);
-    const paginationArray = <T,>(data: T[], page: number, limit: number): T[] => {
-        const startFrom = (page - 1) * limit;
-        const end = page * limit;
-        return data.slice(startFrom, end);
-    };
+    const { totalPage, paginatedData } = usePagination(tableData, Number(searchParams.get("page")) || 1, limit);
 
     if (isLoading) return <div>Chargement des signalements...</div>;
     if (error) return <div>Erreur lors du chargement des signalements.</div>;
@@ -49,13 +45,7 @@ const TableReport = () => {
 
     return (
         <>
-            <Table
-                bordered
-                noCaption
-                headers={["statut", "pseudo", "date de création", "commune (département)", "thème"]}
-                data={paginationArray(tableData, Number(searchParams.get("page")) || 1, 10)} // Gets the page number from the url, if missing or invalid go to page 1
-                fixed
-            />
+            <Table bordered noCaption headers={["statut", "pseudo", "date de création", "commune (département)", "thème"]} data={paginatedData} fixed />
 
             <div className="center-pagination">
                 <PaginationReport totalPage={totalPage} searchParams={searchParams} setSearchParams={setSearchParams} />

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -7,7 +7,6 @@ import { useCommunityStore } from "@/store/useCommunityStore";
 import { REPORTS_API_URL } from "@/constants/urls";
 import type { GetReportData } from "@/constants/reports/types";
 import PaginationReport from "./PaginationReport";
-import { useEffect } from "react";
 
 const transformReportsToTableData = (reports: GetReportData[]) => {
     return reports.map((report) => [
@@ -41,12 +40,6 @@ const TableReport = () => {
         const end = page * limit;
         return data.slice(startFrom, end);
     };
-
-    // go to initial page (page 1) when totalPage changes
-    useEffect(() => {
-        setSearchParams((prev) => ({ ...prev, page: "1" }));
-        return () => {};
-    }, [totalPage]);
 
     if (isLoading) return <div>Chargement des signalements...</div>;
     if (error) return <div>Erreur lors du chargement des signalements.</div>;


### PR DESCRIPTION
- Ajout d’un filtre  de nombre de résultats par page (limit) 
- Synchro des filtres, tri, pagination et limit avec l’URL (params query) via _useSearchParams_ pour une navigation et partage d’URL cohérents...
-  Ajout du param **fields** afin de limiter les données récupérées à celles utilisées dans le tableau.