### PR TITLE
Feat/repondre report

### DIFF
--- a/src/api/reportsData.ts
+++ b/src/api/reportsData.ts
@@ -94,13 +94,11 @@ export async function postReportsReply(reportsIds: number[], body: PostReply): P
                     headers: {
                         "Content-Type": "application/json",
                         Accept: "application/json",
-                        "X-Requested-With": "XMLHttpRequest",
                     },
                 });
             })
         );
-    } catch (error) {
-        console.error("Erreur dans postReportsReply :", error);
+    } catch {
         return null;
     }
 }

--- a/src/api/reportsData.ts
+++ b/src/api/reportsData.ts
@@ -1,13 +1,13 @@
-import { useCommunityStore } from "@/store/useCommunityStore";
 import { useQuery } from "@tanstack/react-query";
-import { useUserStore } from "@/store/useUserStore";
-import { useReportStore } from "@/store/useReportStore";
-import { CommunityReport, FilterState, PostReport, reportData, SketchReport, StatusKey } from "@/constants/reports/types";
-import { REPORTS_API_URL } from "@/constants/urls";
 import { transformExtent } from "ol/proj";
 import { Extent, isEmpty } from "ol/extent";
-import { axiosApi } from ".";
 import { parseContentRange } from "@/constants/utils";
+import { REPORTS_API_URL } from "@/constants/urls";
+import { useCommunityStore } from "@/store/useCommunityStore";
+import { useUserStore } from "@/store/useUserStore";
+import { useReportStore } from "@/store/useReportStore";
+import { CommunityReport, FilterState, PostReport, reportData, SketchReport, StatusKey, PostReply } from "@/constants/reports/types";
+import { axiosApi } from ".";
 
 export const isDigital = (value: string): boolean => {
     const regex = /^[1-9]\d*$/;
@@ -83,6 +83,26 @@ export async function getTableReports(
         currentPage,
         searchReport,
     };
+}
+
+export async function postReportsReply(reportsIds: number[], body: PostReply): Promise<PostReply[] | null> {
+    try {
+        return await Promise.all(
+            reportsIds.map(async (reportId) => {
+                const urlReply = `${REPORTS_API_URL}/${reportId}/replies`;
+                return await axiosApi.post(urlReply, body, {
+                    headers: {
+                        "Content-Type": "application/json",
+                        Accept: "application/json",
+                        "X-Requested-With": "XMLHttpRequest",
+                    },
+                });
+            })
+        );
+    } catch (error) {
+        console.error("Erreur dans postReportsReply :", error);
+        return null;
+    }
 }
 
 export async function getCommunityThemes(communityId: number): Promise<string[]> {

--- a/src/components/FilterAndSortReport.tsx
+++ b/src/components/FilterAndSortReport.tsx
@@ -142,8 +142,6 @@ const FilterAndSortReport = () => {
 
     return (
         <>
-            <h1 className="visuallyhidden">Tous les signalements</h1>
-
             <form ref={formRef} className="filter-report">
                 <div>
                     <p className="report-subTitle">Trier par : </p>

--- a/src/components/Layout/MapToolbar.tsx
+++ b/src/components/Layout/MapToolbar.tsx
@@ -2,7 +2,7 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Select } from "@codegouvfr/react-dsfr/Select";
 import { fr } from "@codegouvfr/react-dsfr";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { useCommunityStore, useLocalStorageStore, useMapStore, useReportStore } from "@/store";
+import { useCommunityStore, useLocalStorageStore, useMapStore } from "@/store";
 
 import "./MapToolbar.css";
 import { useTranslation } from "@/i18n";
@@ -14,7 +14,6 @@ const MapToolbar: React.FC = () => {
     const buttonGroupRef = useRef<HTMLDivElement>(null);
 
     const { community, mapLayers, communityLayers } = useCommunityStore();
-    const { tableDrawerOpened, setTableDrawerOpened } = useReportStore();
     const { mapWorkingLayer, setMapWorkingLayer } = useMapStore();
     const { localStorageData, setLocalStorage } = useLocalStorageStore();
 
@@ -49,10 +48,6 @@ const MapToolbar: React.FC = () => {
             setMapWorkingLayer(initWorkingLayer);
         }
     }, [mapWorkingLayer, workingLayers, localStorageData, setMapWorkingLayer]);
-
-    const toggleTableReportsDrawer = useCallback(() => {
-        setTableDrawerOpened(!tableDrawerOpened);
-    }, [tableDrawerOpened, setTableDrawerOpened]);
 
     const handleWorkingLayerChange = useCallback(
         (value: string) => {

--- a/src/components/Layout/MapToolbar.tsx
+++ b/src/components/Layout/MapToolbar.tsx
@@ -139,9 +139,6 @@ const MapToolbar: React.FC = () => {
             </div>
 
             <div className={`map-toolbar-bottom-inner`}>
-                <Button iconId="ri-table-view" onClick={toggleTableReportsDrawer}>
-                    {t("all_reports")}
-                </Button>
                 <Select
                     label={t("working_layer")}
                     nativeSelectProps={{

--- a/src/components/TransformReportsToTableData.tsx
+++ b/src/components/TransformReportsToTableData.tsx
@@ -18,7 +18,7 @@ const TransformReportsToTableData = (reports: CommunityReport[]) => {
     const { t } = useTranslation({ GetReportsLayer });
     const { localStorageData } = useLocalStorageStore();
     const { map } = useMapStore();
-    const { isChecked, setIsChecked, reportTableWidth, setSelectedLine } = useReportStore();
+    const { isChecked, setIsChecked, reportTableWidth, setSelectedLine, setSelectedReport } = useReportStore();
 
     const clusterLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
     const clusterSource = clusterLayer?.getSource() as VectorSource;
@@ -54,7 +54,7 @@ const TransformReportsToTableData = (reports: CommunityReport[]) => {
         const rasterLayers = map?.getAllLayers();
         const layers = rasterLayers?.filter((layer) => layer.getVisible() === true && layer instanceof TileLayer);
         const higherLayer = layers?.reduce((minLay, lay) => (!minLay || Number(lay.getZIndex()) < Number(minLay?.getZIndex()) ? lay : minLay));
-        const theLayerZoom = higherLayer?.getMaxZoom();
+        const theLayerZoom = higherLayer?.getMaxZoom() - 2;
 
         view.setZoom(theLayerZoom ?? view.getZoom());
 
@@ -124,7 +124,7 @@ const TransformReportsToTableData = (reports: CommunityReport[]) => {
                         iconId="fr-icon-road-map-line"
                         className="fr-icon--sm fr-mr-7v"
                         priority="tertiary no outline"
-                        title="Afficher sur la carte"
+                        title="Afficher le signalement"
                         onClick={() => handleShowOnMap(report)}
                     />
                     <Button
@@ -132,7 +132,7 @@ const TransformReportsToTableData = (reports: CommunityReport[]) => {
                         className="fr-icon--sm"
                         priority="tertiary no outline"
                         title="Afficher sur la carte"
-                        onClick={() => handleShowOnMap(report)}
+                        onClick={() => setSelectedReport(report)}
                     />
                 </div>,
             ],

--- a/src/constants/reports/types.ts
+++ b/src/constants/reports/types.ts
@@ -5,7 +5,7 @@ import { Coordinate } from "ol/coordinate";
 import { Pixel } from "ol/pixel";
 import VectorSource from "ol/source/Vector";
 
-export type StatusKey = "submit" | "pending" | "valid" | "reject" | "test";
+export type StatusKey = "submit" | "pending0" | "pending" | "pending1" | "pending2" | "valid" | "valid0" | "reject" | "reject0" | "test";
 export type SketchType = "Point" | "Ligne" | "MultiPolygone";
 export enum SketchFeatureType {
     Point = "Point",
@@ -83,6 +83,11 @@ export interface PostReport {
     comment: string;
     attributes: { community: number; theme: string; attributes: PostThemeReport };
     sketch?: SketchReport | null;
+}
+export interface PostReply {
+    title?: string;
+    content: string;
+    status: string;
 }
 
 export interface FileUpload {

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -58,8 +58,13 @@ export const otherMarkers = markersStyles.map((style) => {
 export const reportImgStatus = {
     submit: { img: imgSubmit, text: "Reçu dans nos services" },
     pending: { img: imgPending, text: "En cours de traitement" },
+    pending0: { img: imgPending, text: "En demande de qualification" },
+    pending1: { img: imgPending, text: "En attente de saisie" },
+    pending2: { img: imgPending, text: "En attente de validation" },
     valid: { img: imgValid, text: "Pris en compte" },
+    valid0: { img: imgValid, text: "Déjà pris en compte" },
     reject: { img: imgReject, text: "Rejeté (hors spéc.)" },
+    reject0: { img: imgReject, text: "Rejeté (hors de propos)" },
     test: { img: imgTest, text: "En mode test" },
 };
 
@@ -528,4 +533,16 @@ export const addFeaturesInBatches = (source: VectorSource, features: Feature[], 
 
 export const extentEquals = (e1: Extent, e2: Extent) => {
     return e1[0] === e2[0] && e1[1] === e2[1] && e1[2] === e2[2] && e1[3] === e2[3];
+};
+export const statusLabels = {
+    submit: "Reçu dans nos services",
+    pending0: "En demande de qualification",
+    pending: "En cours de traitement",
+    pending1: "En attente de saisie",
+    pending2: "En attente de validation",
+    valid: "Pris en compte",
+    valid0: "Déjà pris en compte",
+    reject: "Rejeté (hors spéc.)",
+    reject0: "Rejeté (hors de propos)",
+    test: "En mode test",
 };

--- a/src/features/navigation/MainMap.tsx
+++ b/src/features/navigation/MainMap.tsx
@@ -124,7 +124,7 @@ export default function MainMap() {
     const mapToolbarHeader = document.getElementById("map-toolbar-header");
 
     return (
-        <div className={fr.cx("fr-grid-row")} style={{ position: "relative" }}>
+        <div className={(fr.cx("fr-grid-row"), "grid-map-container")}>
             <div
                 className={cx(fr.cx("fr-col"), "map-view")}
                 ref={mapTargetRef}

--- a/src/features/navigation/MainMap.tsx
+++ b/src/features/navigation/MainMap.tsx
@@ -20,7 +20,6 @@ import ReportDrawer from "../reports/ReportDrawer";
 import { Cluster } from "ol/source";
 import VectorLayer from "ol/layer/Vector";
 import { clusterStyle } from "@/constants/styles";
-import TableReportDrawer from "../reports/table/TableReportDrawer";
 import { REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import useGetMapControls from "./controls";
 import WorkingLayerDrawer from "../working-layer/WorkingLayerDrawer";
@@ -125,7 +124,7 @@ export default function MainMap() {
     const mapToolbarHeader = document.getElementById("map-toolbar-header");
 
     return (
-        <div className={fr.cx("fr-grid-row")}>
+        <div className={fr.cx("fr-grid-row")} style={{ position: "relative" }}>
             <div
                 className={cx(fr.cx("fr-col"), "map-view")}
                 ref={mapTargetRef}

--- a/src/features/navigation/MainMap.tsx
+++ b/src/features/navigation/MainMap.tsx
@@ -135,7 +135,6 @@ export default function MainMap() {
             <GetAllLayers />
 
             <ReportDrawer />
-            <TableReportDrawer />
             <WorkingLayerDrawer />
         </div>
     );

--- a/src/features/navigation/controls/CatalogControl.tsx
+++ b/src/features/navigation/controls/CatalogControl.tsx
@@ -27,7 +27,7 @@ const CatalogControl: React.FC = () => {
             type: "json",
             urls: [],
         },
-        position: "top-left",
+        position: "top-right",
     });
 };
 

--- a/src/features/navigation/controls/DrawingControl.tsx
+++ b/src/features/navigation/controls/DrawingControl.tsx
@@ -10,7 +10,7 @@ const DrawingControl: React.FC = () => {
     const { t } = useTranslation({ DrawingControl });
     const drawingControl = new Drawing({
         collapsed: true,
-        position: "top-left",
+        position: "top-right",
         removable: true,
         layerDescription: {
             title: t("layer_title"),

--- a/src/features/navigation/controls/index.ts
+++ b/src/features/navigation/controls/index.ts
@@ -24,8 +24,8 @@ const useGetMapControls = (): Collection<Control> | Control[] | undefined => {
             placeholder: t("search_engine_placeholder"),
         }),
         new ScaleLine(),
-        new GeoportalZoom({ position: "top-left", zoomInTipLabel: "Zoom In", zoomOutTipLabel: "Zoom Out" }),
-        new GeoportalFullScreen({ position: "bottom-right", tipLabel: t("full_screen_label") }),
+        new GeoportalZoom({ position: "top-right", zoomInTipLabel: "Zoom In", zoomOutTipLabel: "Zoom Out" }),
+        new GeoportalFullScreen({ position: "top-right", tipLabel: t("full_screen_label") }),
         catalogControl,
         centerToReportControl,
     ];

--- a/src/features/navigation/controls/index.ts
+++ b/src/features/navigation/controls/index.ts
@@ -24,8 +24,8 @@ const useGetMapControls = (): Collection<Control> | Control[] | undefined => {
             placeholder: t("search_engine_placeholder"),
         }),
         new ScaleLine(),
-        new GeoportalZoom({ position: "top-right", zoomInTipLabel: "Zoom In", zoomOutTipLabel: "Zoom Out" }),
-        new GeoportalFullScreen({ position: "top-right", tipLabel: t("full_screen_label") }),
+        new GeoportalZoom({ position: "bottom-right", zoomInTipLabel: "Zoom In", zoomOutTipLabel: "Zoom Out" }),
+        new GeoportalFullScreen({ position: "bottom-right", tipLabel: t("full_screen_label") }),
         catalogControl,
         centerToReportControl,
     ];

--- a/src/features/navigation/layers/index.tsx
+++ b/src/features/navigation/layers/index.tsx
@@ -1,18 +1,33 @@
-import { useCommunityStore, useMapStore } from "@/store";
+import { useCommunityStore, useMapStore, useReportStore } from "@/store";
 import GetWMTSLayer from "./GetWMTSLayer";
 import GetWMSLayer from "./GetWMSLayer";
 import GetWFSLayer from "./GetWFSLayer";
 import { CommunityLayer } from "@/constants/communities/types";
 import GetReportsLayer from "./GetReportsLayer";
+import { useCallback } from "react";
+import Button from "@codegouvfr/react-dsfr/Button";
 
 const GetAllLayers = () => {
     const { communityLayers } = useCommunityStore();
+    const { tableDrawerOpened, setTableDrawerOpened } = useReportStore();
+
+    const toggleTableReportsDrawer = useCallback(() => {
+        setTableDrawerOpened(!tableDrawerOpened);
+    }, [setTableDrawerOpened]);
+
     const { map } = useMapStore();
     if (!communityLayers || !map) return null;
 
     return (
         <>
             <GetReportsLayer />
+            <Button
+                iconId="fr-icon-discuss-line"
+                className="btn-show-drawer fr-icon--sm"
+                priority="tertiary"
+                title="Afficher le tableau de signalement"
+                onClick={toggleTableReportsDrawer}
+            />
             {communityLayers.map((layer: CommunityLayer, index: number) => {
                 const geoservice = layer.geoservice;
                 switch (geoservice.type) {

--- a/src/features/navigation/layers/index.tsx
+++ b/src/features/navigation/layers/index.tsx
@@ -11,7 +11,7 @@ const GetAllLayers = () => {
     const { communityLayers } = useCommunityStore();
     const { tableDrawerOpened, setTableDrawerOpened } = useReportStore();
 
-    const toggleTableReportsDrawer = useCallback(() => {
+    const displayTableReportsDrawer = useCallback(() => {
         setTableDrawerOpened(!tableDrawerOpened);
     }, [setTableDrawerOpened]);
 
@@ -26,7 +26,7 @@ const GetAllLayers = () => {
                 className="btn-show-drawer fr-icon--sm"
                 priority="tertiary"
                 title="Afficher le tableau de signalement"
-                onClick={toggleTableReportsDrawer}
+                onClick={displayTableReportsDrawer}
             />
             {communityLayers.map((layer: CommunityLayer, index: number) => {
                 const geoservice = layer.geoservice;

--- a/src/features/navigation/map-view.css
+++ b/src/features/navigation/map-view.css
@@ -29,3 +29,10 @@ form[id^="GPcoordinateSearchForm"] {
         height: 70vh;
     }
 }
+.btn-show-drawer {
+    position: absolute;
+    right: 15px;
+    top: 270px;
+    border-radius: 4px;
+    background-color: white;
+}

--- a/src/features/navigation/map-view.css
+++ b/src/features/navigation/map-view.css
@@ -1,3 +1,7 @@
+.grid-map-container {
+    position: relative;
+}
+
 .map-view {
     /* position: absolute; */
     width: 100%;
@@ -32,7 +36,7 @@ form[id^="GPcoordinateSearchForm"] {
 .btn-show-drawer {
     position: absolute;
     right: 15px;
-    top: 270px;
+    top: 138px;
     border-radius: 4px;
     background-color: white;
 }

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const { community, addAlertMessage } = useCommunityStore();
-    const { reports, selectedReport, setReports } = useReportStore();
+    const { reports, selectedReport, setReports, setTableDrawerOpened } = useReportStore();
 
     const { map } = useMapStore();
 
@@ -98,7 +98,11 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
         }
     };
 
-    return <ReportForm handleClose={handleCloseDrawer} handleDelete={handleDeleteReport} handleSubmit={handleUpdateReport} />;
+    const handleCloseEditReportDrawer = () => {
+        handleCloseDrawer();
+        setTableDrawerOpened(true);
+    };
+    return <ReportForm handleClose={handleCloseEditReportDrawer} handleDelete={handleDeleteReport} handleSubmit={handleUpdateReport} />;
 };
 
 export default EditReport;

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { Feature, MapBrowserEvent } from "ol";
 import Layer from "ol/layer/Layer";
 import VectorSource from "ol/source/Vector";
@@ -11,6 +11,7 @@ import { useCommunityStore, useMapStore, useReportStore } from "@/store";
 import DrawerComponent from "@/components/DrawerComponent";
 import ShowReport from "./ShowReport";
 import CreateReport from "./CreateReport";
+import TableReportDrawer from "./table/TableReportDrawer";
 
 const ReportDrawer = () => {
     const [drawerOpened, setDrawerOpened] = useState<boolean>(false);
@@ -52,6 +53,7 @@ const ReportDrawer = () => {
 
         setDrawerOpened(false);
         setEditReport(false);
+        setTableDrawerOpened(false);
         setSelectedReport(null);
         setSelectedFeatures([]);
     }, [map, selectedReport, alertMessages, removeAlertMessage, setEditReport, setSelectedFeatures, setSelectedReport]);
@@ -209,8 +211,21 @@ const ReportDrawer = () => {
         };
     }, [drawerOpened, selectedReport, handleDrawingAdd]);
 
+    useEffect(() => {
+        if (drawerOpened) {
+            setTableDrawerOpened(false);
+            setResponseDrawerOpened(false);
+        } else if (responseDrawerOpened) {
+            setDrawerOpened(false);
+            setTableDrawerOpened(false);
+        } else if (tableDrawerOpened) {
+            setDrawerOpened(false);
+            setResponseDrawerOpened(false);
+        }
+    }, [drawerOpened, responseDrawerOpened, setDrawerOpened, setResponseDrawerOpened, setTableDrawerOpened, tableDrawerOpened]);
+
     return (
-        <DrawerComponent anchor="left" isOpen={drawerOpened} create={!selectedReport} onClose={handleCloseDrawer}>
+        <DrawerComponent anchor="left" isOpen={drawerOpened || tableDrawerOpened || responseDrawerOpened} create={!selectedReport} onClose={handleCloseDrawer}>
             <>
                 {drawerOpened ? (
                     selectedReport ? (
@@ -218,6 +233,13 @@ const ReportDrawer = () => {
                     ) : (
                         <CreateReport handleCloseDrawer={handleCloseDrawer} />
                     )
+                ) : tableDrawerOpened ? (
+                    <TableReportDrawer handleCloseDrawer={handleCloseDrawer} />
+                ) : responseDrawerOpened ? (
+                    <div className="table-report-drawer" style={{ width: reportTableWidth }}>
+                        <h1>RESPOOOOOOOOOONSE </h1>
+                        <ShowReport handleCloseDrawer={handleCloseDrawer} />
+                    </div>
                 ) : null}
             </>
         </DrawerComponent>

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -7,18 +7,35 @@ import { getClickedMapReport, getReportSketchFeatures, REPORTS_LAYER_TYPE } from
 import { clearClusterStyles } from "@/constants/reports/utils/cluster";
 import { getCenterReportMessage, showCenterReportButtons } from "@/constants/utils";
 import { ParamsReport, toolNames } from "@/constants/reports/types";
-import { useCommunityStore, useMapStore, useReportStore } from "@/store";
+import { useCommunityStore, useMapStore, useModalStore, useReportStore } from "@/store";
+import Button from "@codegouvfr/react-dsfr/Button";
 import DrawerComponent from "@/components/DrawerComponent";
 import ShowReport from "./ShowReport";
 import CreateReport from "./CreateReport";
 import TableReportDrawer from "./table/TableReportDrawer";
+import OpenReplyReportModal from "./forms/OpenReplyReportModal";
 
 const ReportDrawer = () => {
-    const [drawerOpened, setDrawerOpened] = useState<boolean>(false);
     const { mapWorkingLayer } = useMapStore();
 
-    const { reports, selectedReport, editReport, selectedFeatures, setEditReport, setSelectedReport, setSelectedFeatures } = useReportStore();
+    const {
+        reports,
+        selectedReport,
+        editReport,
+        selectedFeatures,
+        setEditReport,
+        setSelectedReport,
+        setSelectedFeatures,
+        drawerOpened,
+        setDrawerOpened,
+        tableDrawerOpened,
+        responseDrawerOpened,
+        setTableDrawerOpened,
+        setResponseDrawerOpened,
+    } = useReportStore();
     const { map, setClickedMapFeature } = useMapStore();
+
+    const { replyReportModal } = useModalStore();
     const { alertMessages, removeAlertMessage } = useCommunityStore();
 
     const clusterLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
@@ -53,11 +70,14 @@ const ReportDrawer = () => {
 
         setDrawerOpened(false);
         setEditReport(false);
-        setTableDrawerOpened(false);
+        setTableDrawerOpened(!tableDrawerOpened && true);
         setSelectedReport(null);
         setSelectedFeatures([]);
     }, [map, selectedReport, alertMessages, removeAlertMessage, setEditReport, setSelectedFeatures, setSelectedReport]);
 
+    useEffect(() => {
+        console.log("tableDrawerOpened : ", tableDrawerOpened);
+    }, [tableDrawerOpened]);
     const handleSingleClick = useCallback(
         (evt: MapBrowserEvent) => {
             if (selectedFeatures?.find((f) => f?.get("new"))) return;
@@ -225,24 +245,33 @@ const ReportDrawer = () => {
     }, [drawerOpened, responseDrawerOpened, setDrawerOpened, setResponseDrawerOpened, setTableDrawerOpened, tableDrawerOpened]);
 
     return (
-        <DrawerComponent anchor="left" isOpen={drawerOpened || tableDrawerOpened || responseDrawerOpened} create={!selectedReport} onClose={handleCloseDrawer}>
-            <>
-                {drawerOpened ? (
-                    selectedReport ? (
-                        <ShowReport handleCloseDrawer={handleCloseDrawer} />
-                    ) : (
-                        <CreateReport handleCloseDrawer={handleCloseDrawer} />
-                    )
-                ) : tableDrawerOpened ? (
-                    <TableReportDrawer handleCloseDrawer={handleCloseDrawer} />
-                ) : responseDrawerOpened ? (
-                    <div className="table-report-drawer" style={{ width: reportTableWidth }}>
-                        <h1>RESPOOOOOOOOOONSE </h1>
-                        <ShowReport handleCloseDrawer={handleCloseDrawer} />
-                    </div>
-                ) : null}
-            </>
-        </DrawerComponent>
+        <>
+            <DrawerComponent anchor="left" isOpen={drawerOpened || tableDrawerOpened} create={!selectedReport} onClose={handleCloseDrawer}>
+                <>
+                    {drawerOpened ? (
+                        <>
+                            <Button
+                                iconId="fr-icon-arrow-left-line"
+                                className="fr-icon--sm fr-mr-7v"
+                                priority="tertiary no outline"
+                                title="Afficher le signalement"
+                                onClick={() => {
+                                    setTableDrawerOpened(true);
+                                    setDrawerOpened(false);
+                                }}
+                            >
+                                Tous les signalements
+                            </Button>
+                            {selectedReport ? <ShowReport handleCloseDrawer={handleCloseDrawer} /> : <CreateReport handleCloseDrawer={handleCloseDrawer} />}
+                        </>
+                    ) : tableDrawerOpened ? (
+                        <TableReportDrawer handleCloseDrawer={handleCloseDrawer} />
+                    ) : null}
+                </>
+            </DrawerComponent>
+            <OpenReplyReportModal modal={replyReportModal} onClose={() => setResponseDrawerOpened(false)} />
+            {/*   <div className="table-report-drawer" style={{ width: reportTableWidth }}></div>  */}
+        </>
     );
 };
 

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -75,9 +75,6 @@ const ReportDrawer = () => {
         setSelectedFeatures([]);
     }, [map, selectedReport, alertMessages, removeAlertMessage, setEditReport, setSelectedFeatures, setSelectedReport]);
 
-    useEffect(() => {
-        console.log("tableDrawerOpened : ", tableDrawerOpened);
-    }, [tableDrawerOpened]);
     const handleSingleClick = useCallback(
         (evt: MapBrowserEvent) => {
             if (selectedFeatures?.find((f) => f?.get("new"))) return;
@@ -270,7 +267,6 @@ const ReportDrawer = () => {
                 </>
             </DrawerComponent>
             <OpenReplyReportModal modal={replyReportModal} onClose={() => setResponseDrawerOpened(false)} />
-            {/*   <div className="table-report-drawer" style={{ width: reportTableWidth }}></div>  */}
         </>
     );
 };

--- a/src/features/reports/forms/OpenReplyReportModal.tsx
+++ b/src/features/reports/forms/OpenReplyReportModal.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "@/i18n";
+import { postReportsReply } from "@/api/reportsData";
+import { useReportStore } from "@/store";
+import { PostReply } from "@/constants/reports/types";
+import { statusLabels } from "@/constants/utils";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import Select from "@codegouvfr/react-dsfr/Select";
+import TransformReportsToTableData from "@/components/TransformReportsToTableData";
+
+interface Props {
+    modal: ReturnType<typeof createModal>;
+    onClose: () => void;
+}
+
+const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
+    const { filteredReports, isChecked, reports, setIsChecked } = useReportStore();
+    const queryClient = useQueryClient();
+
+    const { t } = useTranslation({ OpenReplyReportModal });
+    const [selectedReport, setSelectedReport] = useState<number[]>();
+
+    const [status, setStatus] = useState("");
+    const [content, setContent] = useState("");
+
+    const reportsToUse = filteredReports.length > 0 ? filteredReports : (reports ?? []);
+    const tableData = TransformReportsToTableData(reportsToUse);
+
+    const checkedIds = React.useMemo(() => {
+        return tableData.filter((res) => !!isChecked[String(res.id)]).map((res) => res.id);
+    }, [tableData, isChecked]);
+
+    const CheckedIdStatus = React.useMemo(() => {
+        return tableData.filter((res) => !!isChecked[String(res.id)]).map((checkedStatus) => checkedStatus.exportData.status);
+    }, [tableData, isChecked]);
+
+    type MutationParams = {
+        reportsId: number[];
+        body: PostReply;
+    };
+
+    const mutation = useMutation<PostReply[] | null, Error, MutationParams>({
+        mutationFn: ({ reportsId, body }) => postReportsReply(reportsId, body),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["reports"] });
+            setContent("");
+            setStatus("");
+            setIsChecked({});
+        },
+        onError: (error) => {
+            console.error("Erreur d'ajout :", error);
+        },
+    });
+
+    useEffect(() => {
+        if (checkedIds.length > 0 && (selectedReport?.length !== checkedIds.length || !checkedIds.every((id, index) => id === selectedReport[index]))) {
+            setSelectedReport(checkedIds);
+        }
+    }, [checkedIds, selectedReport]);
+
+    return (
+        <modal.Component
+            title={` ${t("open_title")} ${selectedReport?.length === 1 ? "au " + selectedReport : ["aux signalements sélectionnés"]}`}
+            iconId="fr-icon-info-fill"
+            buttons={[
+                {
+                    iconId: "ri-check-line",
+                    children: t("send_report"),
+                    onClick: async () => {
+                        mutation.mutate({ reportsId: selectedReport || [], body: { title: "should not be empty !", content, status } });
+                    },
+                },
+                {
+                    iconId: "ri-check-line",
+                    onClick: onClose,
+                    children: t("back_to_reports"),
+                },
+            ]}
+        >
+            <Input
+                label={t("open_title")}
+                textArea
+                nativeTextAreaProps={{
+                    onChange: (event) => setContent(event.target.value),
+                    value: content,
+                }}
+            />
+            <Select
+                label="Label pour liste déroulante"
+                nativeSelectProps={{
+                    onChange: (event) => setStatus(event.target.value),
+                    value: status,
+                }}
+            >
+                <React.Fragment key=".0">
+                    {CheckedIdStatus.length === 1 ? (
+                        <option value={-1}>{statusLabels[CheckedIdStatus[0]]}</option>
+                    ) : (
+                        <option disabled hidden value="">
+                            Selectionnez un status
+                        </option>
+                    )}
+
+                    {Object.entries(statusLabels).map(([key, label]) => (
+                        <option key={key} value={key}>
+                            {label}
+                        </option>
+                    ))}
+                </React.Fragment>
+            </Select>
+        </modal.Component>
+    );
+};
+
+export default OpenReplyReportModal;

--- a/src/features/reports/forms/OpenReplyReportModal.tsx
+++ b/src/features/reports/forms/OpenReplyReportModal.tsx
@@ -3,8 +3,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "@/i18n";
 import { postReportsReply } from "@/api/reportsData";
 import { useReportStore } from "@/store";
-import { PostReply } from "@/constants/reports/types";
-import { statusLabels } from "@/constants/utils";
+import { PostReply, StatusKey } from "@/constants/reports/types";
+import { reportImgStatus } from "@/constants/utils";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import Select from "@codegouvfr/react-dsfr/Select";
@@ -49,9 +49,6 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
             setStatus("");
             setIsChecked({});
         },
-        onError: (error) => {
-            console.error("Erreur d'ajout :", error);
-        },
     });
 
     useEffect(() => {
@@ -60,9 +57,10 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
         }
     }, [checkedIds, selectedReport]);
 
+    const replay_title = `${selectedReport?.length === 1 ? t("openReplay_title") + selectedReport : t("openReplies_title")}`;
     return (
         <modal.Component
-            title={` ${t("open_title")} ${selectedReport?.length === 1 ? "au " + selectedReport : ["aux signalements sélectionnés"]}`}
+            title={replay_title}
             iconId="fr-icon-info-fill"
             buttons={[
                 {
@@ -80,7 +78,7 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
             ]}
         >
             <Input
-                label={t("open_title")}
+                label={replay_title}
                 textArea
                 nativeTextAreaProps={{
                     onChange: (event) => setContent(event.target.value),
@@ -96,18 +94,20 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
             >
                 <React.Fragment key=".0">
                     {CheckedIdStatus.length === 1 ? (
-                        <option value={-1}>{statusLabels[CheckedIdStatus[0]]}</option>
+                        <option value={-1}>{reportImgStatus[CheckedIdStatus[0]].text || ""}</option>
                     ) : (
                         <option disabled hidden value="">
                             Selectionnez un status
                         </option>
                     )}
-
-                    {Object.entries(statusLabels).map(([key, label]) => (
-                        <option key={key} value={key}>
-                            {label}
-                        </option>
-                    ))}
+                    {Object.keys(reportImgStatus).map((key) => {
+                        const statusKey = key as StatusKey;
+                        return (
+                            <option key={statusKey} value={key}>
+                                {reportImgStatus[statusKey].text}
+                            </option>
+                        );
+                    })}
                 </React.Fragment>
             </Select>
         </modal.Component>

--- a/src/features/reports/forms/OpenReplyReportModal.tsx
+++ b/src/features/reports/forms/OpenReplyReportModal.tsx
@@ -3,8 +3,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "@/i18n";
 import { postReportsReply } from "@/api/reportsData";
 import { useReportStore } from "@/store";
-import { PostReply } from "@/constants/reports/types";
-import { statusLabels } from "@/constants/utils";
+import { PostReply, StatusKey } from "@/constants/reports/types";
+import { reportImgStatus } from "@/constants/utils";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import Select from "@codegouvfr/react-dsfr/Select";
@@ -60,9 +60,15 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
         }
     }, [checkedIds, selectedReport]);
 
+    useEffect(() => {
+        console.log(" ---> : ", Object.keys(reportImgStatus)[1]);
+        console.log(" CheckedIdStatus[0] ---> : ", CheckedIdStatus[0]);
+    }, [CheckedIdStatus]);
+
+    const replay_title = `${selectedReport?.length === 1 ? t("openReplay_title") + selectedReport : t("openReplies_title")}`;
     return (
         <modal.Component
-            title={` ${t("open_title")} ${selectedReport?.length === 1 ? "au " + selectedReport : ["aux signalements sélectionnés"]}`}
+            title={replay_title}
             iconId="fr-icon-info-fill"
             buttons={[
                 {
@@ -80,7 +86,7 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
             ]}
         >
             <Input
-                label={t("open_title")}
+                label={replay_title}
                 textArea
                 nativeTextAreaProps={{
                     onChange: (event) => setContent(event.target.value),
@@ -96,18 +102,20 @@ const OpenReplyReportModal: React.FC<Props> = ({ modal, onClose }) => {
             >
                 <React.Fragment key=".0">
                     {CheckedIdStatus.length === 1 ? (
-                        <option value={-1}>{statusLabels[CheckedIdStatus[0]]}</option>
+                        <option value={-1}>{reportImgStatus[CheckedIdStatus[0]].text || ""}</option>
                     ) : (
                         <option disabled hidden value="">
                             Selectionnez un status
                         </option>
                     )}
-
-                    {Object.entries(statusLabels).map(([key, label]) => (
-                        <option key={key} value={key}>
-                            {label}
-                        </option>
-                    ))}
+                    {Object.keys(reportImgStatus).map((key) => {
+                        const statusKey = key as StatusKey;
+                        return (
+                            <option key={statusKey} value={key}>
+                                {reportImgStatus[statusKey].text}
+                            </option>
+                        );
+                    })}
                 </React.Fragment>
             </Select>
         </modal.Component>

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -54,7 +54,7 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     const [loading, setLoading] = useState<boolean>(false);
 
     const { community } = useCommunityStore();
-    const { editReport, selectedReport, selectedFeatures, setSelectedFeatures } = useReportStore();
+    const { editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened } = useReportStore();
 
     const reportTools = useReportTools();
 
@@ -199,6 +199,8 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
         setSelectedFeatures([]);
 
         if (handleClose) handleClose();
+
+        setTableDrawerOpened(true);
     };
 
     const removeFile = (file: File) => {

--- a/src/features/reports/forms/locale/OpenReplyReportModal.locale.tsx
+++ b/src/features/reports/forms/locale/OpenReplyReportModal.locale.tsx
@@ -2,50 +2,53 @@ import { Translations } from "@/i18n/types";
 import { declareComponentKeys } from "i18nifty";
 
 export const OpenReplyReportModalFrTranslations: Translations<"fr">["OpenReplyReportModal"] = {
-    open_title: "Ma réponse",
+    openReplay_title: "Ma réponse au signalement ",
+    openReplies_title: "Ma réponse aux signalements ",
     send_report: "Envoyer",
     back_to_reports: "Retour aux signalements",
-    "status.submit": "Reçu dans nos services",
-    "status.pending0": "En demande de qualification",
-    "status.pending": "En cours de traitement",
-    "status.pending1": "En attente de saisie",
-    "status.pending2": "En attente de validation",
-    "status.valid": "Pris en compte",
-    "status.valid0": "Déjà pris en compte",
-    "status.reject": "Rejeté (hors spéc.)",
-    "status.reject0": "Rejeté (hors de propos)",
-    "status.test": "En mode test",
+    status_submit: "Reçu dans nos services",
+    status_pending0: "En demande de qualification",
+    status_pending: "En cours de traitement",
+    status_pending1: "En attente de saisie",
+    status_pending2: "En attente de validation",
+    status_valid: "Pris en compte",
+    status_valid0: "Déjà pris en compte",
+    status_reject: "Rejeté (hors spéc.)",
+    status_reject0: "Rejeté (hors de propos)",
+    status_test: "En mode test",
 };
 
 export const OpenReplyReportModalEnTranslations: Translations<"en">["OpenReplyReportModal"] = {
-    open_title: "My answer",
+    openReplay_title: "My answer to",
+    openReplies_title: "My answer to",
     send_report: "Send",
     back_to_reports: "Return to reports list",
-    "status.submit": "Received in our services",
-    "status.pending0": "Requesting qualification",
-    "status.pending": "Being processed",
-    "status.pending1": "Awaiting entry",
-    "status.pending2": "Awaiting validation",
-    "status.valid": "Taken into account",
-    "status.valid0": "Already taken into account",
-    "status.reject": "Rejected (Out of spec.)",
-    "status.reject0": "Rejected (Out of relevance)",
-    "status.test": "In test mode",
+    status_submit: "Received in our services",
+    status_pending0: "Requesting qualification",
+    status_pending: "Being processed",
+    status_pending1: "Awaiting entry",
+    status_pending2: "Awaiting validation",
+    status_valid: "Taken into account",
+    status_valid0: "Already taken into account",
+    status_reject: "Rejected (Out of spec.)",
+    status_reject0: "Rejected (Out of relevance)",
+    status_test: "In test mode",
 };
 
 const { i18n } = declareComponentKeys<
-    | "open_title"
+    | "openReplay_title"
+    | "openReplies_title"
     | "send_report"
     | "back_to_reports"
-    | "status.submit"
-    | "status.pending0"
-    | "status.pending"
-    | "status.pending1"
-    | "status.pending2"
-    | "status.valid"
-    | "status.valid0"
-    | "status.reject"
-    | "status.reject0"
-    | "status.test"
+    | "status_submit"
+    | "status_pending0"
+    | "status_pending"
+    | "status_pending1"
+    | "status_pending2"
+    | "status_valid"
+    | "status_valid0"
+    | "status_reject"
+    | "status_reject0"
+    | "status_test"
 >()("OpenReplyReportModal");
 export type I18n = typeof i18n;

--- a/src/features/reports/forms/locale/OpenReplyReportModal.locale.tsx
+++ b/src/features/reports/forms/locale/OpenReplyReportModal.locale.tsx
@@ -1,0 +1,51 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const OpenReplyReportModalFrTranslations: Translations<"fr">["OpenReplyReportModal"] = {
+    open_title: "Ma réponse",
+    send_report: "Envoyer",
+    back_to_reports: "Retour aux signalements",
+    "status.submit": "Reçu dans nos services",
+    "status.pending0": "En demande de qualification",
+    "status.pending": "En cours de traitement",
+    "status.pending1": "En attente de saisie",
+    "status.pending2": "En attente de validation",
+    "status.valid": "Pris en compte",
+    "status.valid0": "Déjà pris en compte",
+    "status.reject": "Rejeté (hors spéc.)",
+    "status.reject0": "Rejeté (hors de propos)",
+    "status.test": "En mode test",
+};
+
+export const OpenReplyReportModalEnTranslations: Translations<"en">["OpenReplyReportModal"] = {
+    open_title: "My answer",
+    send_report: "Send",
+    back_to_reports: "Return to reports list",
+    "status.submit": "Received in our services",
+    "status.pending0": "Requesting qualification",
+    "status.pending": "Being processed",
+    "status.pending1": "Awaiting entry",
+    "status.pending2": "Awaiting validation",
+    "status.valid": "Taken into account",
+    "status.valid0": "Already taken into account",
+    "status.reject": "Rejected (Out of spec.)",
+    "status.reject0": "Rejected (Out of relevance)",
+    "status.test": "In test mode",
+};
+
+const { i18n } = declareComponentKeys<
+    | "open_title"
+    | "send_report"
+    | "back_to_reports"
+    | "status.submit"
+    | "status.pending0"
+    | "status.pending"
+    | "status.pending1"
+    | "status.pending2"
+    | "status.valid"
+    | "status.valid0"
+    | "status.reject"
+    | "status.reject0"
+    | "status.test"
+>()("OpenReplyReportModal");
+export type I18n = typeof i18n;

--- a/src/features/reports/report.css
+++ b/src/features/reports/report.css
@@ -1,3 +1,101 @@
+.table-report-drawer {
+    padding: 0px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.table-report-searchFilter {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+}
+.filter-report {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.filter-report__wrapper {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.filter-report__wrapper > div {
+    width: 100%;
+}
+
+.filter-report button {
+    display: flex;
+    justify-content: center;
+}
+
+.filter-report .sumbit {
+    display: flex;
+    justify-content: flex-start;
+    gap: 16px;
+}
+
+.filter-report__select {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0px !important;
+}
+
+.sort-report__wrapper {
+    display: flex;
+    gap: 10px;
+}
+
+.table-report__table table th,
+.table-report__table table td {
+    text-align: center;
+    justify-items: center;
+    color: var(--grey-200-850);
+}
+
+.table-report__table table thead td:first-child,
+.table-report__table table thead th:first-child {
+    width: 100px;
+}
+
+.table-report__sort {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--grey-200-850);
+}
+
+.report-subTitle {
+    margin-bottom: 0.5rem;
+}
+
+.report-subTitle,
+.report-textResult {
+    font-weight: bold;
+}
+
+.report-infos-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.report-btns {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.report-nbrSelectedLines {
+    color: var(--grey-425-625);
+}
+
+.report-footer {
+    display: flex;
+    justify-content: space-between;
+}
+
 .theme-radio {
     padding: 4px !important;
 }

--- a/src/features/reports/report.css
+++ b/src/features/reports/report.css
@@ -147,8 +147,8 @@
 }
 
 .report-drawer {
-    max-width: 500px;
-    padding: 10px 12px 36px 140px;
+    max-width: 855px;
+    padding: 20px 16px;
 }
 
 .report-drawer .note {

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -2,12 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { CSVLink } from "react-csv";
 import { getTableReports, deleteCommunityReportAPI } from "@/api/reportsData";
-import { useReportStore } from "@/store";
+import { useReportStore, useModalStore } from "@/store";
+import { useCommunityStore } from "@/store/useCommunityStore";
 import { REPORT_TABLE_LIMIT_OPTIONS } from "@/constants/reports/utils";
 import type { CommunityReport } from "@/constants/reports/types";
 import { StatusMessage } from "@/constants/communities/types";
 import { applyFiltersToReports } from "@/constants/reports/utils/reportFilters";
-import { useCommunityStore } from "@/store/useCommunityStore";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { Table } from "@codegouvfr/react-dsfr/Table";
 import { Button } from "@codegouvfr/react-dsfr/Button";
@@ -39,10 +39,9 @@ const TableReport = () => {
         sortBy,
         setSortBy,
         setCurrentPage,
-        setResponseDrawerOpened,
-        selectedReport,
     } = useReportStore();
 
+    const { replyReportModal } = useModalStore();
     const filters = useMemo(
         () => ({
             status: currentFilters.status,
@@ -194,7 +193,11 @@ const TableReport = () => {
                                 title="Supprimer un signalement"
                                 priority="secondary"
                             />
-                            <Button type="button" disabled={selectedReport === null ? true : false} onClick={() => setResponseDrawerOpened(true)}>
+                            <Button
+                                nativeButtonProps={replyReportModal.buttonProps}
+                                type="button"
+                                disabled={!isChecked || !Object.values(isChecked).some(Boolean)}
+                            >
                                 répondre
                             </Button>
                         </div>

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -39,6 +39,8 @@ const TableReport = () => {
         sortBy,
         setSortBy,
         setCurrentPage,
+        setResponseDrawerOpened,
+        selectedReport,
     } = useReportStore();
 
     const filters = useMemo(
@@ -192,7 +194,7 @@ const TableReport = () => {
                                 title="Supprimer un signalement"
                                 priority="secondary"
                             />
-                            <Button type="button" onClick={() => console.log("this is for th' next step")}>
+                            <Button type="button" disabled={selectedReport === null ? true : false} onClick={() => setResponseDrawerOpened(true)}>
                                 répondre
                             </Button>
                         </div>

--- a/src/features/reports/table/TableReportDrawer.tsx
+++ b/src/features/reports/table/TableReportDrawer.tsx
@@ -22,7 +22,7 @@ const TableReportDrawer = ({ handleCloseDrawer }: Props) => {
                 </Button>
             </div>
             <h1>
-                <span className="fr-icon-discuss-line fr-icon--lg" aria-hidden="true"></span> Signalements
+                <span className="fr-icon-discuss-line fr-icon--lg" aria-hidden="true" /> Signalements
             </h1>
             <div className="table-report-searchFilter">
                 <SearchReport />

--- a/src/features/reports/table/TableReportDrawer.tsx
+++ b/src/features/reports/table/TableReportDrawer.tsx
@@ -3,40 +3,42 @@ import { useReportStore } from "@/store";
 import Button from "@codegouvfr/react-dsfr/Button";
 import SearchReport from "@/components/SearchReport";
 import FilterAndSortReport from "@/components/FilterAndSortReport";
-import DrawerComponent from "@/components/DrawerComponent";
 import TableReport from "./TableReport";
 import "./table-report-drawer.css";
 
-const TableReportDrawer = () => {
+interface Props {
+    handleCloseDrawer: () => void;
+}
+
+const TableReportDrawer = ({ handleCloseDrawer }: Props) => {
     const [showFilter, setShowFilter] = useState(false);
-    const { tableDrawerOpened, setTableDrawerOpened, reportTableWidth } = useReportStore();
 
-    const handleCloseDrawer = () => {
-        setTableDrawerOpened(false);
-    };
-
+    const { reportTableWidth } = useReportStore();
     return (
-        <DrawerComponent anchor="left" isOpen={tableDrawerOpened} onClose={handleCloseDrawer}>
-            <div className="table-report-drawer" style={{ width: reportTableWidth }}>
-                <h1>
-                    <span className="fr-icon-discuss-line fr-icon--lg" aria-hidden="true"></span> Signalements
-                </h1>
-                <div className="table-report-searchFilter">
-                    <SearchReport />
-                    <Button
-                        type="button"
-                        onClick={() => setShowFilter(!showFilter)}
-                        priority="secondary"
-                        iconId={`${!showFilter ? "fr-icon-equalizer-line" : "fr-icon-close-line"}`}
-                    >
-                        Filtres
-                    </Button>
-                </div>
-
-                {showFilter && <FilterAndSortReport />}
-                <TableReport />
+        <div className="table-report-drawer" style={{ width: reportTableWidth }}>
+            <div className="drawer-close">
+                <Button iconId="ri-close-line" onClick={handleCloseDrawer} priority="tertiary no outline">
+                    Fermer
+                </Button>
             </div>
-        </DrawerComponent>
+            <h1>
+                <span className="fr-icon-discuss-line fr-icon--lg" aria-hidden="true"></span> Signalements
+            </h1>
+            <div className="table-report-searchFilter">
+                <SearchReport />
+                <Button
+                    type="button"
+                    onClick={() => setShowFilter(!showFilter)}
+                    priority="secondary"
+                    iconId={`${!showFilter ? "fr-icon-equalizer-line" : "fr-icon-close-line"}`}
+                >
+                    Filtres
+                </Button>
+            </div>
+
+            {showFilter && <FilterAndSortReport />}
+            <TableReport />
+        </div>
     );
 };
 

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -8,6 +8,7 @@ import { CarteEnTranslations } from "@/pages/locale/Carte.locale";
 import { GetReportsLayerEnTranslations } from "@/features/navigation/layers/locale/GetReportsLayer.locale";
 import { AttachmentListEnTranslations } from "@/features/reports/forms/locale/AttachmentList.locale";
 import { ConfirmCancelModalEnTranslations } from "@/features/reports/forms/locale/ConfirmCancelModal.locale";
+import { OpenReplyReportModalEnTranslations } from "@/features/reports/forms/locale/OpenReplyReportModal.locale";
 import { DrawingFormEnTranslations } from "@/features/reports/forms/locale/DrawingForm.locale";
 import { ImportSketchFileEnTranslations } from "@/features/reports/forms/locale/ImportSketchFile.locale";
 import { ReportFormEnTranslations } from "@/features/reports/forms/locale/ReportForm.locale";
@@ -38,6 +39,7 @@ export const translations: Translations<"en"> = {
     GetReportsLayer: GetReportsLayerEnTranslations,
     AttachmentList: AttachmentListEnTranslations,
     ConfirmCancelModal: ConfirmCancelModalEnTranslations,
+    OpenReplyReportModal: OpenReplyReportModalEnTranslations,
     DrawingForm: DrawingFormEnTranslations,
     ImportSketchFile: ImportSketchFileEnTranslations,
     ReportForm: ReportFormEnTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -8,6 +8,7 @@ import { CarteFrTranslations } from "@/pages/locale/Carte.locale";
 import { GetReportsLayerFrTranslations } from "@/features/navigation/layers/locale/GetReportsLayer.locale";
 import { AttachmentListFrTranslations } from "@/features/reports/forms/locale/AttachmentList.locale";
 import { ConfirmCancelModalFrTranslations } from "@/features/reports/forms/locale/ConfirmCancelModal.locale";
+import { OpenReplyReportModalFrTranslations } from "@/features/reports/forms/locale/OpenReplyReportModal.locale";
 import { DrawingFormFrTranslations } from "@/features/reports/forms/locale/DrawingForm.locale";
 import { ImportSketchFileFrTranslations } from "@/features/reports/forms/locale/ImportSketchFile.locale";
 import { ReportFormFrTranslations } from "@/features/reports/forms/locale/ReportForm.locale";
@@ -38,6 +39,7 @@ export const translations: Translations<"fr"> = {
     GetReportsLayer: GetReportsLayerFrTranslations,
     AttachmentList: AttachmentListFrTranslations,
     ConfirmCancelModal: ConfirmCancelModalFrTranslations,
+    OpenReplyReportModal: OpenReplyReportModalFrTranslations,
     DrawingForm: DrawingFormFrTranslations,
     ImportSketchFile: ImportSketchFileFrTranslations,
     ReportForm: ReportFormFrTranslations,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -26,6 +26,7 @@ export type ComponentKey =
     | import("../features/navigation/controls/locale/useGetMapControls.locale").I18n
     | import("../features/reports/forms/locale/AttachmentList.locale").I18n
     | import("../features/reports/forms/locale/ConfirmCancelModal.locale").I18n
+    | import("../features/reports/forms/locale/OpenReplyReportModal.locale").I18n
     | import("../features/reports/forms/locale/DrawingForm.locale").I18n
     | import("../features/reports/forms/locale/ImportSketchFile.locale").I18n
     | import("../features/reports/forms/locale/ReportForm.locale").I18n

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,3 +3,4 @@ export { useMapStore } from "./useMapStore";
 export { useCommunityStore } from "./useCommunityStore";
 export { useLocalStorageStore } from "./useLocalStorageStore";
 export { useReportStore } from "./useReportStore";
+export { useModalStore } from "./useModalStore";

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -1,11 +1,11 @@
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 
 import { create } from "zustand";
-interface useModalStore {
+interface ModalState {
     replyReportModal: ReturnType<typeof createModal>;
 }
 const confirmModal = createModal({ id: "answerreport-modal", isOpenedByDefault: false });
 
-export const useModalStore = create<useModalStore>(() => ({
+export const useModalStore = create<ModalState>(() => ({
     replyReportModal: confirmModal,
 }));

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -1,0 +1,11 @@
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+
+import { create } from "zustand";
+interface useModalStore {
+    replyReportModal: ReturnType<typeof createModal>;
+}
+const confirmModal = createModal({ id: "answerreport-modal", isOpenedByDefault: false });
+
+export const useModalStore = create<useModalStore>(() => ({
+    replyReportModal: confirmModal,
+}));

--- a/src/store/useReportStore.ts
+++ b/src/store/useReportStore.ts
@@ -32,6 +32,10 @@ interface ReportStore {
     setSelectedLine: (selectedLine: number) => void;
     sortBy: string | undefined;
     setSortBy: (sortBy: string) => void;
+    drawerOpened: boolean;
+    setDrawerOpened: (drawerOpened: boolean) => void;
+    responseDrawerOpened: boolean;
+    setResponseDrawerOpened: (responseDrawerOpened: boolean) => void;
 }
 export const useReportStore = create<ReportStore>((set, get) => ({
     reports: [],
@@ -92,4 +96,8 @@ export const useReportStore = create<ReportStore>((set, get) => ({
     setSelectedLine: (selectedLine: number) => set({ selectedLine }),
     sortBy: undefined,
     setSortBy: (sortBy) => set({ sortBy }),
+    drawerOpened: false,
+    setDrawerOpened: (drawerOpened: boolean) => set({ drawerOpened }),
+    responseDrawerOpened: false,
+    setResponseDrawerOpened: (responseDrawerOpened: boolean) => set({ responseDrawerOpened }),
 }));


### PR DESCRIPTION
- Ajout de la fonctionnalité permettant de répondre à un ou plusieurs signalements via une popin (textArea + menu déroulant prérempli par le status du signalement séléctionné) :
<img width="1455" height="693" alt="image" src="https://github.com/user-attachments/assets/cdc9c19c-70cd-4e98-b879-b48019bb7469" />

- Amélioration de l’affichage des labels de statut et thème.
- Ajouter une action sur la flèche du tableau, permettant d'ouvrir le volet du signalement concerné.

<img width="1278" height="374" alt="image" src="https://github.com/user-attachments/assets/5bf0e705-786f-4826-8a3d-0462795ba962" />
<img width="1292" height="379" alt="image" src="https://github.com/user-attachments/assets/e10f88d2-2e3e-49e0-9bfc-0ee15890b70b" />



-  Supprimer le boutton 'Afficher les signalement' et le remplacer par une icone sur la map :

<img width="479" height="492" alt="image" src="https://github.com/user-attachments/assets/f277494d-9ce5-49d1-9c90-4492b2ee94e6" />
