### PR TITLE
Feat/section suivi

### DIFF
--- a/src/api/repliesData.ts
+++ b/src/api/repliesData.ts
@@ -1,0 +1,35 @@
+import { Replies } from "@/constants/reports/types";
+import { axiosApi } from ".";
+import { REPORTS_API_URL } from "@/constants/urls";
+import { useQuery } from "@tanstack/react-query";
+
+async function getReportReplies(reportId: number): Promise<Replies> {
+    const res = await axiosApi.get(`${REPORTS_API_URL}/${reportId}`);
+    return res.data;
+}
+
+export const useGetReportReplies = (reportId?: number) => {
+    return useQuery<Replies>({
+        queryKey: reportId ? ["reportReplies", reportId] : ["reportReplies"],
+        queryFn: () => getReportReplies(reportId!),
+        enabled: !!reportId,
+    });
+};
+
+// const { data } = useQuery<Replies>({
+//     queryKey: reportId ? ["report", reportId] : ["report"],
+//     queryFn: () => getReportReplies(reportId!),
+//     enabled: !!reportId,
+// });
+
+// export const useGetCommunityByIdAPI = (communityId: string) => {
+//     const { community } = useCommunityStore();
+//     const { user } = useUserStore();
+//     queryClient = useQueryClient();
+//     return useQuery({
+//         queryKey: ["COMMUNITY_DATA_" + communityId],
+//         queryFn: () => getCommunityById(communityId),
+//         retry: 2,
+//         enabled: !community && isDigital(communityId) && !!user,
+//     });
+// };

--- a/src/api/repliesData.ts
+++ b/src/api/repliesData.ts
@@ -1,7 +1,7 @@
-import { Replies } from "@/constants/reports/types";
 import { axiosApi } from ".";
-import { REPORTS_API_URL } from "@/constants/urls";
 import { useQuery } from "@tanstack/react-query";
+import { Replies } from "@/constants/reports/types";
+import { REPORTS_API_URL } from "@/constants/urls";
 
 async function getReportReplies(reportId: number): Promise<Replies> {
     const res = await axiosApi.get(`${REPORTS_API_URL}/${reportId}`);
@@ -15,21 +15,3 @@ export const useGetReportReplies = (reportId?: number) => {
         enabled: !!reportId,
     });
 };
-
-// const { data } = useQuery<Replies>({
-//     queryKey: reportId ? ["report", reportId] : ["report"],
-//     queryFn: () => getReportReplies(reportId!),
-//     enabled: !!reportId,
-// });
-
-// export const useGetCommunityByIdAPI = (communityId: string) => {
-//     const { community } = useCommunityStore();
-//     const { user } = useUserStore();
-//     queryClient = useQueryClient();
-//     return useQuery({
-//         queryKey: ["COMMUNITY_DATA_" + communityId],
-//         queryFn: () => getCommunityById(communityId),
-//         retry: 2,
-//         enabled: !community && isDigital(communityId) && !!user,
-//     });
-// };

--- a/src/api/reportsData.ts
+++ b/src/api/reportsData.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { transformExtent } from "ol/proj";
 import { Extent, isEmpty } from "ol/extent";
 import { parseContentRange } from "@/constants/utils";
-import { REPORTS_API_URL, USER_PROFILE_API_URL } from "@/constants/urls";
+import { REPORTS_API_URL } from "@/constants/urls";
 import { useCommunityStore } from "@/store/useCommunityStore";
 import { useUserStore } from "@/store/useUserStore";
 import { useReportStore } from "@/store/useReportStore";
@@ -14,10 +14,6 @@ export const isDigital = (value: string): boolean => {
     return regex.test(value);
 };
 
-export async function getUserRole() {
-    const res = await axiosApi.get(`${USER_PROFILE_API_URL}`);
-    return res.data;
-}
 export const getCommunityReportSketch = (report: reportData) => {
     const sketchJson = report.sketch ? JSON.parse(report.sketch) : null;
     return sketchJson

--- a/src/api/reportsData.ts
+++ b/src/api/reportsData.ts
@@ -33,10 +33,7 @@ export const getCommunityReportSketch = (report: reportData) => {
           }
         : null;
 };
-// export async function getReportReplies(reportId: number): Promise<Replies> {
-//     const res = await axiosApi.get(`${REPORTS_API_URL}/${reportId}`);
-//     return res.data;
-// }
+
 export async function getTableReports(
     communityId: number,
     limit: number = 100,

--- a/src/api/reportsData.ts
+++ b/src/api/reportsData.ts
@@ -2,11 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { transformExtent } from "ol/proj";
 import { Extent, isEmpty } from "ol/extent";
 import { parseContentRange } from "@/constants/utils";
-import { REPORTS_API_URL } from "@/constants/urls";
+import { REPORTS_API_URL, USER_PROFILE_API_URL } from "@/constants/urls";
 import { useCommunityStore } from "@/store/useCommunityStore";
 import { useUserStore } from "@/store/useUserStore";
 import { useReportStore } from "@/store/useReportStore";
-import { CommunityReport, FilterState, PostReport, reportData, SketchReport, StatusKey, PostReply, Replies } from "@/constants/reports/types";
+import { CommunityReport, FilterState, PostReport, reportData, SketchReport, StatusKey, Reply } from "@/constants/reports/types";
 import { axiosApi } from ".";
 
 export const isDigital = (value: string): boolean => {
@@ -14,6 +14,10 @@ export const isDigital = (value: string): boolean => {
     return regex.test(value);
 };
 
+export async function getUserRole() {
+    const res = await axiosApi.get(`${USER_PROFILE_API_URL}`);
+    return res.data;
+}
 export const getCommunityReportSketch = (report: reportData) => {
     const sketchJson = report.sketch ? JSON.parse(report.sketch) : null;
     return sketchJson
@@ -29,10 +33,10 @@ export const getCommunityReportSketch = (report: reportData) => {
           }
         : null;
 };
-export async function getReportReplies(reportId: number): Promise<Replies> {
-    const res = await axiosApi.get(`${REPORTS_API_URL}/${reportId}`);
-    return res.data;
-}
+// export async function getReportReplies(reportId: number): Promise<Replies> {
+//     const res = await axiosApi.get(`${REPORTS_API_URL}/${reportId}`);
+//     return res.data;
+// }
 export async function getTableReports(
     communityId: number,
     limit: number = 100,
@@ -96,19 +100,24 @@ export async function getTableReports(
     };
 }
 
-export async function postReportsReply(reportsIds: number[], body: PostReply): Promise<PostReply[] | null> {
+export async function postReportsReply(reportsIds: number | number[], body: Reply): Promise<Reply[] | null> {
     try {
-        return await Promise.all(
-            reportsIds.map(async (reportId) => {
+        const idsArray = Array.isArray(reportsIds) ? reportsIds : [reportsIds];
+
+        const results = await Promise.all(
+            idsArray.map(async (reportId) => {
                 const urlReply = `${REPORTS_API_URL}/${reportId}/replies`;
-                return await axiosApi.post(urlReply, body, {
+                const response = await axiosApi.post(urlReply, body, {
                     headers: {
                         "Content-Type": "application/json",
                         Accept: "application/json",
                     },
                 });
+                return response.data;
             })
         );
+
+        return results;
     } catch {
         return null;
     }

--- a/src/components/ReportFiltersComponent.tsx
+++ b/src/components/ReportFiltersComponent.tsx
@@ -4,8 +4,13 @@ import Badge from "@codegouvfr/react-dsfr/Badge";
 import { useCommunityStore, useReportStore } from "@/store";
 import { getTableReports } from "@/api/reportsData";
 import CreateTableData from "@/features/reports/table/CreateTableData";
-
-const ReportFiltersComponent = () => {
+import { reportImgStatus } from "@/constants/utils";
+import { StatusKey } from "@/constants/reports/types";
+interface ReportFiltersProps {
+    reportStatus: string;
+}
+const ReportFiltersComponent: React.FC<ReportFiltersProps> = ({ reportStatus }) => {
+    // const [status, setStatus] = useState("");
     const {
         reports,
         currentFilters,
@@ -38,7 +43,12 @@ const ReportFiltersComponent = () => {
     const departement = currentReport?.departement ? `${currentReport?.departement.title} (${currentReport?.departement?.name})` : "-";
     const themes =
         currentReport?.attributes && currentReport?.attributes.length > 0 ? currentReport?.attributes.map((attr) => attr.theme || "").join(", ") : "-";
+    // setStatus(currentReport?.status || "-");
     const status = currentReport?.status || "-";
+    // const statusText = reportImgStatus[status as StatusKey].text || "";
+    const statusText = reportImgStatus[status as StatusKey]?.text || "";
+
+    const statusLabel = reportImgStatus[reportStatus as StatusKey]?.text || "";
 
     function convertDateToIso(dateStr: string): string {
         const [day, month, year] = dateStr.split("/");
@@ -46,6 +56,7 @@ const ReportFiltersComponent = () => {
 
         return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
     }
+
     useEffect(() => {
         async function fetchReports() {
             if (!community) return;
@@ -163,7 +174,7 @@ const ReportFiltersComponent = () => {
                     }}
                 >
                     <Badge severity="info" noIcon>
-                        {status}
+                        {statusText !== statusLabel && statusLabel !== "" ? statusLabel : statusText}
                     </Badge>
                 </a>
             </li>

--- a/src/components/ReportFiltersComponent.tsx
+++ b/src/components/ReportFiltersComponent.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useMemo } from "react";
-import Tag from "@codegouvfr/react-dsfr/Tag";
-import Badge from "@codegouvfr/react-dsfr/Badge";
-import { useCommunityStore, useReportStore } from "@/store";
 import { getTableReports } from "@/api/reportsData";
-import CreateTableData from "@/features/reports/table/CreateTableData";
+import { useCommunityStore, useReportStore } from "@/store";
 import { reportImgStatus } from "@/constants/utils";
 import { StatusKey } from "@/constants/reports/types";
+import CreateTableData from "@/features/reports/table/CreateTableData";
+import Tag from "@codegouvfr/react-dsfr/Tag";
+import Badge from "@codegouvfr/react-dsfr/Badge";
 interface ReportFiltersProps {
     reportStatus: string;
 }
-const ReportFiltersComponent: React.FC<ReportFiltersProps> = ({ reportStatus }) => {
-    // const [status, setStatus] = useState("");
+const ReportFiltersComponent = ({ reportStatus }: ReportFiltersProps) => {
     const {
         reports,
         currentFilters,
@@ -43,9 +42,7 @@ const ReportFiltersComponent: React.FC<ReportFiltersProps> = ({ reportStatus }) 
     const departement = currentReport?.departement ? `${currentReport?.departement.title} (${currentReport?.departement?.name})` : "-";
     const themes =
         currentReport?.attributes && currentReport?.attributes.length > 0 ? currentReport?.attributes.map((attr) => attr.theme || "").join(", ") : "-";
-    // setStatus(currentReport?.status || "-");
     const status = currentReport?.status || "-";
-    // const statusText = reportImgStatus[status as StatusKey].text || "";
     const statusText = reportImgStatus[status as StatusKey]?.text || "";
 
     const statusLabel = reportImgStatus[reportStatus as StatusKey]?.text || "";

--- a/src/constants/reports/types.ts
+++ b/src/constants/reports/types.ts
@@ -70,13 +70,14 @@ export interface CommunityReport {
     attributes?: CommunityTheme[];
 }
 
-type Reply = {
-    id: number;
-    author: AuthorData;
+export type Reply = {
+    id?: number;
+    community?: number;
+    author?: AuthorData;
     title: string;
     content: string;
     status: string;
-    date: string;
+    date?: string;
 };
 export interface Replies {
     replies: Reply[];
@@ -98,11 +99,6 @@ export interface PostReport {
     comment?: string;
     attributes?: { community?: number; theme?: string; attributes?: PostThemeReport };
     sketch?: SketchReport | null;
-}
-export interface PostReply {
-    title?: string;
-    content: string;
-    status: string;
 }
 
 export interface FileUpload {

--- a/src/constants/reports/types.ts
+++ b/src/constants/reports/types.ts
@@ -25,6 +25,10 @@ export type ParamsReport = {
     closeFunc: () => void;
 };
 
+export type MutationReportParams = {
+    reportId: number;
+    body: Reply;
+};
 type CommuneData = {
     name: string;
     title: string;

--- a/src/features/navigation/layers/locale/GetReportsLayer.locale.tsx
+++ b/src/features/navigation/layers/locale/GetReportsLayer.locale.tsx
@@ -4,12 +4,14 @@ import { declareComponentKeys } from "i18nifty";
 export const GetReportsLayerFrTranslations: Translations<"fr">["GetReportsLayer"] = {
     reports_title: "Signalements",
     reports_legend: "Légende signalements",
+    report_reply: "Répondre",
 };
 
 export const GetReportsLayerEnTranslations: Translations<"en">["GetReportsLayer"] = {
     reports_title: "Reports",
     reports_legend: "Reports legend",
+    report_reply: "Reply",
 };
 
-const { i18n } = declareComponentKeys<"reports_title" | "reports_legend">()("GetReportsLayer");
+const { i18n } = declareComponentKeys<"reports_title" | "reports_legend" | "report_reply">()("GetReportsLayer");
 export type I18n = typeof i18n;

--- a/src/features/reports/CreateReport.tsx
+++ b/src/features/reports/CreateReport.tsx
@@ -1,15 +1,14 @@
-import { useCommunityStore, useMapStore, useReportStore } from "@/store";
-
-import { CommunityTheme, StatusMessage } from "@/constants/communities/types";
+import { useState } from "react";
+import { Feature } from "ol";
+import { useTranslation } from "@/i18n";
+import { postCommunityReportAttachments } from "@/api/attachmentData";
 import { postCommunityReport } from "@/api/reportsData";
+import { useCommunityStore, useMapStore, useReportStore } from "@/store";
 import { CommunityReport, PostReport, PostThemeReport } from "@/constants/reports/types";
 import { clearDrawingLayer, getFeatureGeometryWKT } from "@/constants/utils";
-import ReportForm from "./forms/ReportForm";
-import { postCommunityReportAttachments } from "@/api/attachmentData";
-import { Feature } from "ol";
+import { CommunityTheme, StatusMessage } from "@/constants/communities/types";
 import { getReportSketch } from "@/constants/reports/utils";
-import { useState } from "react";
-import { useTranslation } from "@/i18n";
+import ReportForm from "./forms/ReportForm";
 
 interface Props {
     handleCloseDrawer: () => void;

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useTranslation } from "@/i18n";
 import { Feature } from "ol";
 import VectorSource from "ol/source/Vector";
@@ -17,17 +16,12 @@ interface Props {
 
 const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const { community, addAlertMessage } = useCommunityStore();
-    const { reports, selectedReport, setReports, setTableDrawerOpened, setEditReport } = useReportStore();
+    const { reports, selectedReport, setReports, setTableDrawerOpened } = useReportStore();
 
     const { map } = useMapStore();
 
     const { t } = useTranslation({ EditReport });
 
-    useEffect(() => {
-        setEditReport(true);
-
-        return () => {};
-    }, [setEditReport]);
     if (!community || !map || !selectedReport) return null;
 
     const handleDeleteReport = async () => {
@@ -111,7 +105,6 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
 
     return (
         <>
-            EditReport
             <ReportForm handleClose={handleCloseEditReportDrawer} handleDelete={handleDeleteReport} handleSubmit={handleUpdateReport} />
         </>
     );

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -9,6 +9,7 @@ import VectorSource from "ol/source/Vector";
 import { getReportSketch, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import ReportForm from "./forms/ReportForm";
 import { useTranslation } from "@/i18n";
+import { useEffect } from "react";
 
 interface Props {
     handleCloseDrawer: () => void;
@@ -16,12 +17,17 @@ interface Props {
 
 const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const { community, addAlertMessage } = useCommunityStore();
-    const { reports, selectedReport, setReports, setTableDrawerOpened } = useReportStore();
+    const { reports, selectedReport, setReports, setTableDrawerOpened, setEditReport } = useReportStore();
 
     const { map } = useMapStore();
 
     const { t } = useTranslation({ EditReport });
 
+    useEffect(() => {
+        setEditReport(true);
+
+        return () => {};
+    }, [setEditReport]);
     if (!community || !map || !selectedReport) return null;
 
     const handleDeleteReport = async () => {
@@ -102,7 +108,13 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
         handleCloseDrawer();
         setTableDrawerOpened(true);
     };
-    return <ReportForm handleClose={handleCloseEditReportDrawer} handleDelete={handleDeleteReport} handleSubmit={handleUpdateReport} />;
+
+    return (
+        <>
+            EditReport
+            <ReportForm handleClose={handleCloseEditReportDrawer} handleDelete={handleDeleteReport} handleSubmit={handleUpdateReport} />
+        </>
+    );
 };
 
 export default EditReport;

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -1,15 +1,15 @@
-import { deleteCommunityReportAPI, updateCommunityReport } from "@/api/reportsData";
-import { CommunityTheme, StatusMessage } from "@/constants/communities/types";
-import { PostReport, PostThemeReport } from "@/constants/reports/types";
-import { useCommunityStore, useMapStore, useReportStore } from "@/store";
-import { deleteCommunityReportAllAttachments, postCommunityReportAttachments } from "@/api/attachmentData";
-import { clearDrawingLayer, getFeatureGeometryWKT } from "@/constants/utils";
+import { useEffect } from "react";
+import { useTranslation } from "@/i18n";
 import { Feature } from "ol";
 import VectorSource from "ol/source/Vector";
+import { deleteCommunityReportAPI, updateCommunityReport } from "@/api/reportsData";
+import { deleteCommunityReportAllAttachments, postCommunityReportAttachments } from "@/api/attachmentData";
+import { useCommunityStore, useMapStore, useReportStore } from "@/store";
+import { CommunityTheme, StatusMessage } from "@/constants/communities/types";
+import { PostReport, PostThemeReport } from "@/constants/reports/types";
+import { clearDrawingLayer, getFeatureGeometryWKT } from "@/constants/utils";
 import { getReportSketch, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import ReportForm from "./forms/ReportForm";
-import { useTranslation } from "@/i18n";
-import { useEffect } from "react";
 
 interface Props {
     handleCloseDrawer: () => void;

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -284,10 +284,14 @@ const ReportDrawer = () => {
         }
     }, [drawerOpened, responseDrawerOpened, setDrawerOpened, setResponseDrawerOpened, setTableDrawerOpened, tableDrawerOpened]);
 
-    const ifRole = useMemo(() => {
+    const isAdmin = useMemo(() => {
         const currentUser = userData?.communitiesMember?.filter((cm) => cm.communityId === community?.id);
         return Array.isArray(currentUser) ? currentUser.some((role) => role.role === "admin") : false;
     }, [userData, community?.id]);
+
+    useEffect(() => {
+        if (isAdmin) setEditReport(true);
+    }, [isAdmin, setEditReport]);
 
     return (
         <>
@@ -309,7 +313,7 @@ const ReportDrawer = () => {
                             </Button>
                             {!selectedReport ? (
                                 <CreateReport handleCloseDrawer={handleCloseDrawer} />
-                            ) : ifRole ? (
+                            ) : isAdmin ? (
                                 <EditReport handleCloseDrawer={handleCloseDrawer} />
                             ) : (
                                 <ShowReport handleCloseDrawer={handleCloseDrawer} />

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "@/i18n";
 import { Feature, MapBrowserEvent } from "ol";
 import Layer from "ol/layer/Layer";
@@ -16,6 +16,10 @@ import CreateReport from "./CreateReport";
 import TableReportDrawer from "./table/TableReportDrawer";
 import OpenReplyReportModal from "./forms/OpenReplyReportModal";
 import { HIT_DETECTION_TOLERENCE } from "@/constants";
+// import { getUserRole } from "@/api/reportsData";
+// import { useQuery } from "@tanstack/react-query";
+import { useGetUserProfileAPI } from "@/api/userData";
+import EditReport from "./EditReport";
 
 const ReportDrawer = () => {
     const { t } = useTranslation({ ShowReport });
@@ -45,6 +49,16 @@ const ReportDrawer = () => {
 
     const clickableLayer = map?.getAllLayers().find((layer) => layer.get("name") === mapWorkingLayer);
     const clickableSource = clickableLayer?.getSource() as VectorSource;
+
+    const { community } = useCommunityStore();
+
+    // const { data: userRole } = useQuery({
+    //     queryKey: ["userRole"],
+    //     queryFn: () => getUserRole(),
+    //     enabled: true,
+    // });
+
+    const { data: userData } = useGetUserProfileAPI();
 
     const handleCloseDrawer = useCallback(() => {
         if (!selectedReport) {
@@ -278,6 +292,11 @@ const ReportDrawer = () => {
         }
     }, [drawerOpened, responseDrawerOpened, setDrawerOpened, setResponseDrawerOpened, setTableDrawerOpened, tableDrawerOpened]);
 
+    const ifRole = useMemo(() => {
+        const currentUser = userData?.communitiesMember?.filter((cm) => cm.communityId === community?.id);
+        return Array.isArray(currentUser) ? currentUser.some((role) => role.role === "admin") : false;
+    }, [userData, community?.id]);
+
     return (
         <>
             <DrawerComponent anchor="left" isOpen={drawerOpened || tableDrawerOpened} create={!selectedReport} onClose={handleCloseDrawer}>
@@ -296,7 +315,13 @@ const ReportDrawer = () => {
                             >
                                 {t("report_back")}
                             </Button>
-                            {selectedReport ? <ShowReport handleCloseDrawer={handleCloseDrawer} /> : <CreateReport handleCloseDrawer={handleCloseDrawer} />}
+                            {!selectedReport ? (
+                                <CreateReport handleCloseDrawer={handleCloseDrawer} />
+                            ) : ifRole ? (
+                                <EditReport handleCloseDrawer={handleCloseDrawer} />
+                            ) : (
+                                <ShowReport handleCloseDrawer={handleCloseDrawer} />
+                            )}
                         </>
                     ) : tableDrawerOpened ? (
                         <TableReportDrawer handleCloseDrawer={handleCloseDrawer} />

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -4,21 +4,19 @@ import { Feature, MapBrowserEvent } from "ol";
 import Layer from "ol/layer/Layer";
 import VectorSource from "ol/source/Vector";
 import { Style } from "ol/style";
-import { getClickedMapReport, getReportSketchFeatures, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
-import { clearClusterStyles } from "@/constants/reports/utils/cluster";
-import { getCenterReportMessage, showCenterReportButtons } from "@/constants/utils";
-import { ParamsReport, toolNames } from "@/constants/reports/types";
+import { useGetUserProfileAPI } from "@/api/userData";
 import { useCommunityStore, useMapStore, useReportStore } from "@/store";
+import { HIT_DETECTION_TOLERENCE } from "@/constants";
+import { getClickedMapReport, getReportSketchFeatures, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
+import { getCenterReportMessage, showCenterReportButtons } from "@/constants/utils";
+import { clearClusterStyles } from "@/constants/reports/utils/cluster";
+import { ParamsReport, toolNames } from "@/constants/reports/types";
 import Button from "@codegouvfr/react-dsfr/Button";
 import DrawerComponent from "@/components/DrawerComponent";
 import ShowReport from "./ShowReport";
 import CreateReport from "./CreateReport";
 import TableReportDrawer from "./table/TableReportDrawer";
 import OpenReplyReportModal from "./forms/OpenReplyReportModal";
-import { HIT_DETECTION_TOLERENCE } from "@/constants";
-// import { getUserRole } from "@/api/reportsData";
-// import { useQuery } from "@tanstack/react-query";
-import { useGetUserProfileAPI } from "@/api/userData";
 import EditReport from "./EditReport";
 
 const ReportDrawer = () => {
@@ -51,12 +49,6 @@ const ReportDrawer = () => {
     const clickableSource = clickableLayer?.getSource() as VectorSource;
 
     const { community } = useCommunityStore();
-
-    // const { data: userRole } = useQuery({
-    //     queryKey: ["userRole"],
-    //     queryFn: () => getUserRole(),
-    //     enabled: true,
-    // });
 
     const { data: userData } = useGetUserProfileAPI();
 

--- a/src/features/reports/ReportTracking.tsx
+++ b/src/features/reports/ReportTracking.tsx
@@ -1,0 +1,132 @@
+import React, { useMemo } from "react";
+import { useState } from "react";
+import { useTranslation } from "@/i18n";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postReportsReply } from "@/api/reportsData";
+import { useGetReportReplies } from "@/api/repliesData";
+import { useCommunityStore, useReportStore, useUserStore } from "@/store";
+import { useReplyStore } from "@/store/useReplyStore";
+import { MutationReportParams, Reply, Severity, StatusKey } from "@/constants/reports/types";
+import { reportImgStatus } from "@/constants/utils";
+import Badge from "@codegouvfr/react-dsfr/Badge";
+import Select from "@codegouvfr/react-dsfr/Select";
+import Input from "@codegouvfr/react-dsfr/Input";
+import Button from "@codegouvfr/react-dsfr/Button";
+
+interface ReportTrackingProps {
+    setCommittedStatus: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const ReportTracking: React.FC<ReportTrackingProps> = ({ setCommittedStatus }) => {
+    const [status, setStatus] = useState("");
+    const [content, setContent] = useState("");
+
+    const { user } = useUserStore();
+    const { setIsChecked, setSelectedReport, selectedReport } = useReportStore();
+    const { setReplies } = useReplyStore();
+
+    const queryClient = useQueryClient();
+
+    const { t } = useTranslation({ ReportTracking });
+
+    const reportId = selectedReport?.id;
+    const { data: repliesData } = useGetReportReplies(reportId);
+    const repliesRes = useMemo(() => repliesData?.replies ?? [], [repliesData]);
+
+    const mutation = useMutation<Reply[] | null, Error, MutationReportParams>({
+        mutationFn: ({ reportId, body }) => postReportsReply(reportId, body),
+        onSuccess: (newReplies) => {
+            queryClient.invalidateQueries({ queryKey: ["reportReplies", reportId] });
+            setContent("");
+            setIsChecked({});
+            setSelectedReport(selectedReport);
+            if (newReplies && newReplies.length > 0) {
+                setReplies([...(repliesData?.replies ?? []), ...newReplies]);
+            }
+        },
+    });
+
+    const onSubmitReply = async (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        if (reportId) {
+            setCommittedStatus(status);
+            mutation.mutate({ reportId, body: { title: "", content, status } });
+        }
+    };
+
+    const { community } = useCommunityStore();
+    if (!community || !selectedReport) return;
+
+    return (
+        <>
+            <div className="report-drawer_tracking fr-mx-3v">
+                {repliesRes.map((reply) => {
+                    const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
+                    return (
+                        <div
+                            key={reply.id}
+                            className={`report-drawer_trackingItem  ${reply.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
+                        >
+                            {reply.author?.username === user?.name ? (
+                                <p>
+                                    {reply.author?.username}
+                                    <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
+                                </p>
+                            ) : (
+                                <p>
+                                    <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply.author?.username}
+                                </p>
+                            )}
+
+                            <p className="report-drawer_trackingItem_date"> {reply.date}</p>
+                            <p> {reply.content}</p>
+                            <div className="report-drawer_trackingItem_status">
+                                {t("report_status")}:
+                                <Badge noIcon={hideIcon} severity={reportImgStatus[reply.status as StatusKey].colorType as Severity} className="fr-ml-2v">
+                                    {reply.status}
+                                </Badge>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+            <div>
+                <form className="report-drawer_status fr-mt-6v">
+                    <Select
+                        label={t("report_status")}
+                        nativeSelectProps={{
+                            onChange: (event) => setStatus(event.target.value),
+                            value: status,
+                        }}
+                    >
+                        <React.Fragment key=".0">
+                            <option value={-1}>{reportImgStatus[selectedReport?.status]?.text || ""}</option>
+
+                            {Object.keys(reportImgStatus).map((key) => {
+                                const statusKey = key as StatusKey;
+                                return (
+                                    <option key={statusKey} value={key}>
+                                        {reportImgStatus[statusKey].text}
+                                    </option>
+                                );
+                            })}
+                        </React.Fragment>
+                    </Select>
+                    <Input
+                        label={t("report_content")}
+                        textArea
+                        nativeTextAreaProps={{
+                            onChange: (event) => setContent(event.target.value),
+                            value: content,
+                        }}
+                    />
+                    <Button onClick={onSubmitReply} className="fr-mt-4v">
+                        {t("report_send")}
+                    </Button>
+                </form>
+            </div>
+        </>
+    );
+};
+
+export default ReportTracking;

--- a/src/features/reports/ShowReport.tsx
+++ b/src/features/reports/ShowReport.tsx
@@ -1,43 +1,65 @@
-import { useTranslation } from "@/i18n";
-import { useCommunityStore, useReportStore, useUserStore } from "@/store";
-import Accordion from "@codegouvfr/react-dsfr/Accordion";
-import Button from "@codegouvfr/react-dsfr/Button";
-import SketchList from "./forms/SketchList";
-import EditReport from "./EditReport";
-import ReportFiltersComponent from "@/components/ReportFiltersComponent";
+import React, { useMemo, useRef } from "react";
 import { useState } from "react";
+import { useTranslation } from "@/i18n";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postReportsReply } from "@/api/reportsData";
+import { useCommunityStore, useReportStore, useUserStore } from "@/store";
+import { Reply, Severity, StatusKey } from "@/constants/reports/types";
+import { reportImgStatus } from "@/constants/utils";
+import ReportFiltersComponent from "@/components/ReportFiltersComponent";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import Badge from "@codegouvfr/react-dsfr/Badge";
-import { getReportReplies } from "@/api/reportsData";
-import { useQuery } from "@tanstack/react-query";
-import { Replies, Severity, StatusKey } from "@/constants/reports/types";
-import { reportImgStatus } from "@/constants/utils";
-import React from "react";
 import Select from "@codegouvfr/react-dsfr/Select";
 import Input from "@codegouvfr/react-dsfr/Input";
-import FormAttachments from "./forms/FormAttachments";
+import Accordion from "@codegouvfr/react-dsfr/Accordion";
+import Button from "@codegouvfr/react-dsfr/Button";
+import EditReport from "./EditReport";
+import SketchList from "./forms/SketchList";
+import AttachmentList from "./forms/AttachmentList";
+import { useGetReportReplies } from "@/api/repliesData";
+import { useRepliesStore } from "@/store/userRepliesStore";
 
 interface Props {
     handleCloseDrawer: () => void;
 }
+type MutationParams = {
+    reportId: number;
+    body: Reply;
+};
 
 const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const [openSuivi, setOpenSuivi] = useState(false);
     const [status, setStatus] = useState("");
+    const [committedStatus, setCommittedStatus] = useState("");
     const [content, setContent] = useState("");
 
-    const { user } = useUserStore();
-    const { selectedReport, editReport, setEditReport } = useReportStore();
+    const accordionRef = useRef<HTMLDivElement>(null);
 
+    const { user } = useUserStore();
+    const { setIsChecked, setSelectedReport, selectedReport, editReport } = useReportStore();
+    const { setReplies } = useRepliesStore();
+
+    const queryClient = useQueryClient();
     const { community } = useCommunityStore();
 
     const { t } = useTranslation({ ShowReport });
 
     const reportId = selectedReport?.id;
-    const { data } = useQuery<Replies>({
-        queryKey: reportId ? ["report", reportId] : ["report"],
-        queryFn: () => getReportReplies(reportId!),
-        enabled: !!reportId,
+    const { data: repliesData } = useGetReportReplies(reportId);
+    const repliesRes = useMemo(() => repliesData?.replies ?? [], [repliesData]);
+
+    const mutation = useMutation<Reply[] | null, Error, MutationParams>({
+        mutationFn: ({ reportId, body }) => postReportsReply(reportId, body),
+        onSuccess: (newReplies) => {
+            queryClient.invalidateQueries({ queryKey: ["reportReplies", reportId] });
+            setContent("");
+            setIsChecked({});
+            setSelectedReport(selectedReport);
+            if (newReplies && newReplies.length > 0) {
+                setReplies([...(repliesData?.replies ?? []), ...newReplies]);
+                // setReplies(newReplies);
+            }
+        },
     });
 
     if (!community || !selectedReport) return;
@@ -48,128 +70,155 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const reportTheme = community.themes.find((theme) => theme.theme === selectedTheme.theme);
 
     return (
-        <div className="report-drawer">
-            <h2 className="fr-mt-4v fr-mb-1v fr-text--md">
-                <span className="ri-map-pin-add-line fr-pr-1v" />
-                {t("report_title", { reportId: selectedReport.id })}
-            </h2>
-            <ReportFiltersComponent />
-            <Button onClick={() => setOpenSuivi(true)}>Répondre</Button>
-
-            <div className="fr-mt-12v">
-                <Accordion label={t("report_theme")} defaultExpanded={false}>
-                    <RadioButtons
-                        legend={t("report_theme")}
-                        options={[
-                            {
-                                label: reportTheme?.theme,
-                                nativeInputProps: {
-                                    checked: true,
+        <>
+            SHOWREPORT
+            <div className="report-drawer">
+                <h2 className="fr-mt-4v fr-mb-1v fr-text--md">
+                    <span className="ri-map-pin-add-line fr-pr-1v" />
+                    {t("report_title", { reportId: selectedReport.id })}
+                </h2>
+                <ReportFiltersComponent reportStatus={committedStatus} />
+                <Button
+                    onClick={() => {
+                        setOpenSuivi(true);
+                        setTimeout(() => {
+                            accordionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                        }, 100);
+                    }}
+                >
+                    Répondre
+                </Button>
+                <div className="fr-mt-12v">
+                    <Accordion label={t("report_theme")} defaultExpanded={false}>
+                        <RadioButtons
+                            legend={t("report_theme")}
+                            options={[
+                                {
+                                    label: reportTheme?.theme,
+                                    nativeInputProps: {
+                                        checked: true,
+                                    },
                                 },
-                            },
-                        ]}
-                        state="default"
-                        stateRelatedMessage=""
-                        orientation="vertical"
-                        small
-                        disabled={true}
-                        className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
-                    />
-                </Accordion>
-                <Accordion label={t("report_sketch_list")} defaultExpanded={false}>
-                    <SketchList />
-                </Accordion>
-                {description && (
-                    <Accordion label={t("report_description")} defaultExpanded={false}>
-                        <p>{description}</p>
+                            ]}
+                            state="default"
+                            stateRelatedMessage=""
+                            orientation="vertical"
+                            small
+                            disabled={true}
+                            className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
+                        />
                     </Accordion>
-                )}
+                    <Accordion label={t("report_sketch_list")} defaultExpanded={false}>
+                        <SketchList />
+                    </Accordion>
+                    {description && (
+                        <Accordion label={t("report_description")} defaultExpanded={false}>
+                            <p>{description}</p>
+                        </Accordion>
+                    )}
 
-                <Accordion label={t("report_document_list") + " (" + selectedReport?.attachments.length + ")"}>
-                    <div>
-                        <FormAttachments />
-                        {/* <AttachmentList /> */}
-                    </div>
-                </Accordion>
+                    <Accordion label={t("report_document_list") + " (" + selectedReport?.attachments.length + ")"}>
+                        <div>
+                            {/* <FormAttachments /> */}
+                            <AttachmentList />
+                        </div>
+                    </Accordion>
 
-                <Accordion label={t("report_tracking")} onExpandedChange={(expanded: boolean) => setOpenSuivi(expanded)} expanded={openSuivi}>
-                    <div className="report-drawer_tracking fr-mx-3v">
-                        {data?.replies.map((reply) => {
-                            const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
-                            return (
-                                <div
-                                    key={reply.id}
-                                    className={`report-drawer_trackingItem  ${reply.author.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
-                                >
-                                    {reply.author.username === user?.name ? (
-                                        <p>
-                                            {reply.author.username}
-                                            <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
-                                        </p>
-                                    ) : (
-                                        <p>
-                                            <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply.author.username}
-                                        </p>
-                                    )}
+                    <Accordion
+                        ref={accordionRef}
+                        label={t("report_tracking")}
+                        onExpandedChange={(expanded: boolean) => {
+                            setOpenSuivi(expanded);
+                            if (expanded) {
+                                setReplies(repliesRes);
+                            }
+                        }}
+                        expanded={openSuivi}
+                    >
+                        <div className="report-drawer_tracking fr-mx-3v">
+                            {repliesRes.map((reply) => {
+                                const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
+                                return (
+                                    <div
+                                        key={reply.id}
+                                        className={`report-drawer_trackingItem  ${reply.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
+                                    >
+                                        {reply.author?.username === user?.name ? (
+                                            <p>
+                                                {reply.author?.username}
+                                                <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
+                                            </p>
+                                        ) : (
+                                            <p>
+                                                <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply.author?.username}
+                                            </p>
+                                        )}
 
-                                    <p className="report-drawer_trackingItem_date"> {reply.date}</p>
-                                    <p> {reply.content}</p>
-                                    <div className="report-drawer_trackingItem_status">
-                                        Statut:
-                                        <Badge
-                                            noIcon={hideIcon}
-                                            severity={reportImgStatus[reply.status as StatusKey].colorType as Severity}
-                                            className="fr-ml-2v"
-                                        >
-                                            {reply.status}
-                                        </Badge>
+                                        <p className="report-drawer_trackingItem_date"> {reply.date}</p>
+                                        <p> {reply.content}</p>
+                                        <div className="report-drawer_trackingItem_status">
+                                            Statut:
+                                            <Badge
+                                                noIcon={hideIcon}
+                                                severity={reportImgStatus[reply.status as StatusKey].colorType as Severity}
+                                                className="fr-ml-2v"
+                                            >
+                                                {reply.status}
+                                            </Badge>
+                                        </div>
                                     </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                    <div>
-                        <form className="report-drawer_status fr-mt-6v">
-                            <Select
-                                label={t("report_status")}
-                                nativeSelectProps={{
-                                    onChange: (event) => setStatus(event.target.value),
-                                    value: status,
-                                }}
-                            >
-                                <React.Fragment key=".0">
-                                    <option value={-1}>{reportImgStatus[selectedReport.status].text || ""}</option>
+                                );
+                            })}
+                        </div>
+                        <div>
+                            <form className="report-drawer_status fr-mt-6v">
+                                <Select
+                                    label={t("report_status")}
+                                    nativeSelectProps={{
+                                        onChange: (event) => setStatus(event.target.value),
+                                        value: status,
+                                    }}
+                                >
+                                    <React.Fragment key=".0">
+                                        <option value={-1}>{reportImgStatus[selectedReport.status].text || ""}</option>
 
-                                    {Object.keys(reportImgStatus).map((key) => {
-                                        const statusKey = key as StatusKey;
-                                        return (
-                                            <option key={statusKey} value={key}>
-                                                {reportImgStatus[statusKey].text}
-                                            </option>
-                                        );
-                                    })}
-                                </React.Fragment>
-                            </Select>
-                            <Input
-                                label={t("report_content")}
-                                textArea
-                                nativeTextAreaProps={{
-                                    onChange: (event) => setContent(event.target.value),
-                                    value: content,
-                                }}
-                            />
-                            <Button onClick={() => null} className="fr-mt-4v">
-                                {t("report_send")}
-                            </Button>
-                        </form>
-                    </div>
-                </Accordion>
-            </div>
+                                        {Object.keys(reportImgStatus).map((key) => {
+                                            const statusKey = key as StatusKey;
+                                            return (
+                                                <option key={statusKey} value={key}>
+                                                    {reportImgStatus[statusKey].text}
+                                                </option>
+                                            );
+                                        })}
+                                    </React.Fragment>
+                                </Select>
+                                <Input
+                                    label={t("report_content")}
+                                    textArea
+                                    nativeTextAreaProps={{
+                                        onChange: (event) => setContent(event.target.value),
+                                        value: content,
+                                    }}
+                                />
+                                <Button
+                                    onClick={async (e) => {
+                                        e.preventDefault();
 
-            <div className="buttons">
-                <Button onClick={() => setEditReport(true)}>{t("report_document_modify")}</Button>
+                                        if (reportId) {
+                                            setCommittedStatus(status);
+                                            mutation.mutate({ reportId, body: { title: "Could be empty !", content, status } });
+                                        }
+                                    }}
+                                    className="fr-mt-4v"
+                                >
+                                    {t("report_send")}
+                                </Button>
+                            </form>
+                        </div>
+                    </Accordion>
+                </div>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/src/features/reports/ShowReport.tsx
+++ b/src/features/reports/ShowReport.tsx
@@ -1,23 +1,20 @@
 import React, { useMemo, useRef } from "react";
 import { useState } from "react";
 import { useTranslation } from "@/i18n";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postReportsReply } from "@/api/reportsData";
+
 import { useGetReportReplies } from "@/api/repliesData";
-import { useCommunityStore, useReportStore, useUserStore } from "@/store";
-import { useRepliesStore } from "@/store/userRepliesStore";
-import { MutationReportParams, Reply, Severity, StatusKey } from "@/constants/reports/types";
-import { reportImgStatus } from "@/constants/utils";
+import { useCommunityStore, useReportStore } from "@/store";
+import { useReplyStore } from "@/store/useReplyStore";
+
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
-import Badge from "@codegouvfr/react-dsfr/Badge";
-import Select from "@codegouvfr/react-dsfr/Select";
-import Input from "@codegouvfr/react-dsfr/Input";
+
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
 import ReportFiltersComponent from "@/components/ReportFiltersComponent";
 import AttachmentList from "./forms/AttachmentList";
 import EditReport from "./EditReport";
 import SketchList from "./forms/SketchList";
+import ReportTracking from "./ReportTracking";
 
 interface Props {
     handleCloseDrawer: () => void;
@@ -25,17 +22,13 @@ interface Props {
 
 const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const [openSuivi, setOpenSuivi] = useState(false);
-    const [status, setStatus] = useState("");
     const [committedStatus, setCommittedStatus] = useState("");
-    const [content, setContent] = useState("");
 
     const accordionRef = useRef<HTMLDivElement>(null);
 
-    const { user } = useUserStore();
-    const { setIsChecked, setSelectedReport, selectedReport, editReport } = useReportStore();
-    const { setReplies } = useRepliesStore();
+    const { selectedReport, editReport } = useReportStore();
+    const { setReplies } = useReplyStore();
 
-    const queryClient = useQueryClient();
     const { community } = useCommunityStore();
 
     const { t } = useTranslation({ ShowReport });
@@ -43,19 +36,6 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const reportId = selectedReport?.id;
     const { data: repliesData } = useGetReportReplies(reportId);
     const repliesRes = useMemo(() => repliesData?.replies ?? [], [repliesData]);
-
-    const mutation = useMutation<Reply[] | null, Error, MutationReportParams>({
-        mutationFn: ({ reportId, body }) => postReportsReply(reportId, body),
-        onSuccess: (newReplies) => {
-            queryClient.invalidateQueries({ queryKey: ["reportReplies", reportId] });
-            setContent("");
-            setIsChecked({});
-            setSelectedReport(selectedReport);
-            if (newReplies && newReplies.length > 0) {
-                setReplies([...(repliesData?.replies ?? []), ...newReplies]);
-            }
-        },
-    });
 
     if (!community || !selectedReport) return;
     if (editReport) return <EditReport handleCloseDrawer={handleCloseDrawer} />;
@@ -80,7 +60,7 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
                         }, 100);
                     }}
                 >
-                    Répondre
+                    {t("report_reply")}
                 </Button>
                 <div className="fr-mt-12v">
                     <Accordion label={t("report_theme")} defaultExpanded={false}>
@@ -128,86 +108,7 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
                         }}
                         expanded={openSuivi}
                     >
-                        <div className="report-drawer_tracking fr-mx-3v">
-                            {repliesRes.map((reply) => {
-                                const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
-                                return (
-                                    <div
-                                        key={reply.id}
-                                        className={`report-drawer_trackingItem  ${reply.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
-                                    >
-                                        {reply.author?.username === user?.name ? (
-                                            <p>
-                                                {reply.author?.username}
-                                                <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
-                                            </p>
-                                        ) : (
-                                            <p>
-                                                <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply.author?.username}
-                                            </p>
-                                        )}
-
-                                        <p className="report-drawer_trackingItem_date"> {reply.date}</p>
-                                        <p> {reply.content}</p>
-                                        <div className="report-drawer_trackingItem_status">
-                                            Statut:
-                                            <Badge
-                                                noIcon={hideIcon}
-                                                severity={reportImgStatus[reply.status as StatusKey].colorType as Severity}
-                                                className="fr-ml-2v"
-                                            >
-                                                {reply.status}
-                                            </Badge>
-                                        </div>
-                                    </div>
-                                );
-                            })}
-                        </div>
-                        <div>
-                            <form className="report-drawer_status fr-mt-6v">
-                                <Select
-                                    label={t("report_status")}
-                                    nativeSelectProps={{
-                                        onChange: (event) => setStatus(event.target.value),
-                                        value: status,
-                                    }}
-                                >
-                                    <React.Fragment key=".0">
-                                        <option value={-1}>{reportImgStatus[selectedReport.status].text || ""}</option>
-
-                                        {Object.keys(reportImgStatus).map((key) => {
-                                            const statusKey = key as StatusKey;
-                                            return (
-                                                <option key={statusKey} value={key}>
-                                                    {reportImgStatus[statusKey].text}
-                                                </option>
-                                            );
-                                        })}
-                                    </React.Fragment>
-                                </Select>
-                                <Input
-                                    label={t("report_content")}
-                                    textArea
-                                    nativeTextAreaProps={{
-                                        onChange: (event) => setContent(event.target.value),
-                                        value: content,
-                                    }}
-                                />
-                                <Button
-                                    onClick={async (e) => {
-                                        e.preventDefault();
-
-                                        if (reportId) {
-                                            setCommittedStatus(status);
-                                            mutation.mutate({ reportId, body: { title: "Could be empty !", content, status } });
-                                        }
-                                    }}
-                                    className="fr-mt-4v"
-                                >
-                                    {t("report_send")}
-                                </Button>
-                            </form>
-                        </div>
+                        <ReportTracking setCommittedStatus={setCommittedStatus} />
                     </Accordion>
                 </div>
             </div>

--- a/src/features/reports/ShowReport.tsx
+++ b/src/features/reports/ShowReport.tsx
@@ -3,29 +3,25 @@ import { useState } from "react";
 import { useTranslation } from "@/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postReportsReply } from "@/api/reportsData";
+import { useGetReportReplies } from "@/api/repliesData";
 import { useCommunityStore, useReportStore, useUserStore } from "@/store";
-import { Reply, Severity, StatusKey } from "@/constants/reports/types";
+import { useRepliesStore } from "@/store/userRepliesStore";
+import { MutationReportParams, Reply, Severity, StatusKey } from "@/constants/reports/types";
 import { reportImgStatus } from "@/constants/utils";
-import ReportFiltersComponent from "@/components/ReportFiltersComponent";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Select from "@codegouvfr/react-dsfr/Select";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
+import ReportFiltersComponent from "@/components/ReportFiltersComponent";
+import AttachmentList from "./forms/AttachmentList";
 import EditReport from "./EditReport";
 import SketchList from "./forms/SketchList";
-import AttachmentList from "./forms/AttachmentList";
-import { useGetReportReplies } from "@/api/repliesData";
-import { useRepliesStore } from "@/store/userRepliesStore";
 
 interface Props {
     handleCloseDrawer: () => void;
 }
-type MutationParams = {
-    reportId: number;
-    body: Reply;
-};
 
 const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const [openSuivi, setOpenSuivi] = useState(false);
@@ -48,7 +44,7 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const { data: repliesData } = useGetReportReplies(reportId);
     const repliesRes = useMemo(() => repliesData?.replies ?? [], [repliesData]);
 
-    const mutation = useMutation<Reply[] | null, Error, MutationParams>({
+    const mutation = useMutation<Reply[] | null, Error, MutationReportParams>({
         mutationFn: ({ reportId, body }) => postReportsReply(reportId, body),
         onSuccess: (newReplies) => {
             queryClient.invalidateQueries({ queryKey: ["reportReplies", reportId] });
@@ -57,7 +53,6 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
             setSelectedReport(selectedReport);
             if (newReplies && newReplies.length > 0) {
                 setReplies([...(repliesData?.replies ?? []), ...newReplies]);
-                // setReplies(newReplies);
             }
         },
     });
@@ -71,7 +66,6 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
 
     return (
         <>
-            SHOWREPORT
             <div className="report-drawer">
                 <h2 className="fr-mt-4v fr-mb-1v fr-text--md">
                     <span className="ri-map-pin-add-line fr-pr-1v" />
@@ -119,7 +113,6 @@ const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
 
                     <Accordion label={t("report_document_list") + " (" + selectedReport?.attachments.length + ")"}>
                         <div>
-                            {/* <FormAttachments /> */}
                             <AttachmentList />
                         </div>
                     </Accordion>

--- a/src/features/reports/forms/AttachmentList.tsx
+++ b/src/features/reports/forms/AttachmentList.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) => {
     const { addAlertMessage } = useCommunityStore();
-    const { reports, selectedReport, setReports, isShowReport } = useReportStore();
+    const { reports, selectedReport, setReports, isShowReport, editReport } = useReportStore();
 
     const [loading, setLoading] = useState(false);
 
@@ -52,12 +52,14 @@ const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) =
                             {attachment.name}
                         </a>
 
-                        <Button
-                            iconId="ri-delete-bin-2-fill"
-                            title={t("delete_file", { fileName: attachment.name })}
-                            priority="tertiary"
-                            onClick={() => deleteAttachment(attachment)}
-                        ></Button>
+                        {editReport && (
+                            <Button
+                                iconId="ri-delete-bin-2-fill"
+                                title={t("delete_file", { fileName: attachment.name })}
+                                priority="tertiary"
+                                onClick={() => deleteAttachment(attachment)}
+                            ></Button>
+                        )}
                     </div>
                 ))}
             {newFiles &&

--- a/src/features/reports/forms/AttachmentList.tsx
+++ b/src/features/reports/forms/AttachmentList.tsx
@@ -1,12 +1,12 @@
-import { ErrorFile, ReportAttachment } from "@/constants/reports/types";
-import fileUploadIcon from "../../../icons/file-upload-icon.jpg";
-import Button from "@codegouvfr/react-dsfr/Button";
+import { Fragment, useMemo, useState } from "react";
+import { useTranslation } from "@/i18n";
 import { deleteCommunityReportAttachment } from "@/api/attachmentData";
 import { useCommunityStore, useReportStore } from "@/store";
+import { ErrorFile, ReportAttachment } from "@/constants/reports/types";
 import { StatusMessage } from "@/constants/communities/types";
-import { Fragment, useMemo, useState } from "react";
+import Button from "@codegouvfr/react-dsfr/Button";
 import LoaderComponent from "@/components/LoaderComponent";
-import { useTranslation } from "@/i18n";
+import fileUploadIcon from "../../../icons/file-upload-icon.jpg";
 
 interface Props {
     newFiles?: File[] | null;

--- a/src/features/reports/forms/OpenReplyReportModal.tsx
+++ b/src/features/reports/forms/OpenReplyReportModal.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "@/i18n";
 import { postReportsReply } from "@/api/reportsData";
 import { useModalStore, useReportStore } from "@/store";
-import { PostReply, StatusKey } from "@/constants/reports/types";
+import { Reply, StatusKey } from "@/constants/reports/types";
 import { reportImgStatus } from "@/constants/utils";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/Select";
@@ -36,15 +36,15 @@ const OpenReplyReportModal: React.FC<Props> = ({ onClose }) => {
     }, [tableData, isChecked]);
 
     const CheckedIdStatus = React.useMemo(() => {
-        return tableData.filter((res) => !!isChecked[String(res.id)]).map((checkedStatus) => checkedStatus.exportData.status);
+        return tableData.filter((res) => !!isChecked[String(res.id)]).map((checkedStatus) => checkedStatus.exportData.statusText);
     }, [tableData, isChecked]);
 
     type MutationParams = {
         reportsId: number[];
-        body: PostReply;
+        body: Reply;
     };
 
-    const mutation = useMutation<PostReply[] | null, Error, MutationParams>({
+    const mutation = useMutation<Reply[] | null, Error, MutationParams>({
         mutationFn: ({ reportsId, body }) => postReportsReply(reportsId, body),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["reports"] });

--- a/src/features/reports/forms/OpenReplyReportModal.tsx
+++ b/src/features/reports/forms/OpenReplyReportModal.tsx
@@ -60,6 +60,7 @@ const OpenReplyReportModal: React.FC<Props> = ({ onClose }) => {
             setSelectedReportId(checkedIds);
         }
     }, [checkedIds, selectedReportId]);
+
     useEffect(() => {
         setSelectedReport(selectedReport);
     }, [reports, selectedReport, setSelectedReport]);
@@ -71,7 +72,7 @@ const OpenReplyReportModal: React.FC<Props> = ({ onClose }) => {
             title={replay_title}
             onClose={onClose}
             onConfirm={async () => {
-                mutation.mutate({ reportsId: selectedReportId || [], body: { title: "Could be empty !", content, status } });
+                mutation.mutate({ reportsId: selectedReportId || [], body: { title: "", content, status } });
             }}
             cancelText={t("back_to_reports")}
             confirmText={t("send_report")}
@@ -92,13 +93,14 @@ const OpenReplyReportModal: React.FC<Props> = ({ onClose }) => {
                 }}
             >
                 <React.Fragment key=".0">
-                    {CheckedIdStatus.length === 1 ? (
-                        <option value={-1}>{reportImgStatus[CheckedIdStatus[0]].text || ""}</option>
+                    {CheckedIdStatus.length === 1 && CheckedIdStatus[0] in reportImgStatus ? (
+                        <option value={-1}>{reportImgStatus[CheckedIdStatus[0]].text}</option>
                     ) : (
                         <option value={-1} disabled hidden>
-                            Selectionnez un status
+                            {t("select_status")}
                         </option>
                     )}
+
                     {Object.keys(reportImgStatus).map((key) => {
                         const statusKey = key as StatusKey;
                         return (

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -1,31 +1,30 @@
-import LoaderComponent from "@/components/LoaderComponent";
+import React from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "@/i18n";
+import { Feature } from "ol";
+import { postReportsReply } from "@/api/reportsData";
+import { useGetReportReplies } from "@/api/repliesData";
+import { useCommunityStore, useMapStore, useModalStore, useReportStore, useUserStore } from "@/store";
+import { useRepliesStore } from "@/store/userRepliesStore";
 import { CommunityTheme } from "@/constants/communities/types";
 import { ClickedTool, ErrorFile, PostThemeReport, Reply, ReportTool, Severity, StatusKey } from "@/constants/reports/types";
-import { useCommunityStore, useMapStore, useModalStore, useReportStore, useUserStore } from "@/store";
+import { getThemeAttributes, reportImgStatus } from "@/constants/utils";
+import useReportTools from "@/hooks/reports/useReportTools";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
+import Badge from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
+import Select from "@codegouvfr/react-dsfr/Select";
 import { Upload } from "@codegouvfr/react-dsfr/Upload";
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import LoaderComponent from "@/components/LoaderComponent";
+import ReportFiltersComponent from "@/components/ReportFiltersComponent";
 import ThemeForm from "./ThemeForm";
-import { getThemeAttributes, reportImgStatus } from "@/constants/utils";
 import DrawingForm from "./DrawingForm";
-import { Feature } from "ol";
 import CenterReport from "../CenterReport";
 import ConfirmCancelModal from "./ConfirmCancelModal";
 import AttachmentList from "./AttachmentList";
-import { useTranslation } from "@/i18n";
-import useReportTools from "@/hooks/reports/useReportTools";
-import ReportFiltersComponent from "@/components/ReportFiltersComponent";
-import Badge from "@codegouvfr/react-dsfr/Badge";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postReportsReply } from "@/api/reportsData";
-import Select from "@codegouvfr/react-dsfr/Select";
-import React from "react";
-import { useGetReportReplies } from "@/api/repliesData";
-import { useRepliesStore } from "@/store/userRepliesStore";
-// import CreateTableData from "../table/CreateTableData";
 
 const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
 const maxSizeMB = 3;
@@ -66,18 +65,8 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     const queryClient = useQueryClient();
 
     const { community } = useCommunityStore();
-    const {
-        // filteredReports,
-        setSelectedReport,
-        // isChecked,
-        reports,
-        setIsChecked,
-        editReport,
-        selectedReport,
-        selectedFeatures,
-        setSelectedFeatures,
-        setTableDrawerOpened,
-    } = useReportStore();
+    const { setSelectedReport, reports, setIsChecked, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened } =
+        useReportStore();
 
     const reportTools = useReportTools();
     const { confirmCancelModal } = useModalStore();
@@ -105,7 +94,6 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
             setSelectedReport(selectedReport);
             if (newReplies && newReplies.length > 0) {
                 setReplies([...(repliesData?.replies ?? []), ...newReplies]);
-                // setReplies(newReplies);
             }
         },
     });

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -1,22 +1,18 @@
 import React from "react";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "@/i18n";
 import { Feature } from "ol";
-import { postReportsReply } from "@/api/reportsData";
 import { useGetReportReplies } from "@/api/repliesData";
-import { useCommunityStore, useMapStore, useModalStore, useReportStore, useUserStore } from "@/store";
-import { useRepliesStore } from "@/store/userRepliesStore";
+import { useCommunityStore, useMapStore, useModalStore, useReportStore } from "@/store";
+import { useReplyStore } from "@/store/useReplyStore";
 import { CommunityTheme } from "@/constants/communities/types";
-import { ClickedTool, ErrorFile, PostThemeReport, Reply, ReportTool, Severity, StatusKey } from "@/constants/reports/types";
-import { getThemeAttributes, reportImgStatus } from "@/constants/utils";
+import { ClickedTool, ErrorFile, PostThemeReport, ReportTool } from "@/constants/reports/types";
+import { getThemeAttributes } from "@/constants/utils";
 import useReportTools from "@/hooks/reports/useReportTools";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
-import Badge from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
-import Select from "@codegouvfr/react-dsfr/Select";
 import { Upload } from "@codegouvfr/react-dsfr/Upload";
 import LoaderComponent from "@/components/LoaderComponent";
 import ReportFiltersComponent from "@/components/ReportFiltersComponent";
@@ -25,6 +21,7 @@ import DrawingForm from "./DrawingForm";
 import CenterReport from "../CenterReport";
 import ConfirmCancelModal from "./ConfirmCancelModal";
 import AttachmentList from "./AttachmentList";
+import ReportTracking from "../ReportTracking";
 
 const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
 const maxSizeMB = 3;
@@ -44,8 +41,7 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     const [clickedTool, setClickedTool] = useState<ClickedTool>({ name: "", clicked: false });
 
     const [openSuivi, setOpenSuivi] = useState(false);
-    const [status, setStatus] = useState("");
-    const [content, setContent] = useState("");
+    const [committedStatus, setCommittedStatus] = useState("");
 
     const accordionRef = useRef<HTMLDivElement>(null);
 
@@ -60,43 +56,21 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     const filesRef = useRef<HTMLDivElement>(null);
 
     const [loading, setLoading] = useState<boolean>(false);
-    const [committedStatus, setCommittedStatus] = useState("");
-
-    const queryClient = useQueryClient();
 
     const { community } = useCommunityStore();
-    const { setSelectedReport, reports, setIsChecked, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened } =
-        useReportStore();
+    const { setSelectedReport, reports, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened } = useReportStore();
 
     const reportTools = useReportTools();
     const { confirmCancelModal } = useModalStore();
     const { setClickedControl } = useMapStore();
-    const { setReplies } = useRepliesStore();
-    const { user } = useUserStore();
+    const { setReplies } = useReplyStore();
 
     const { t } = useTranslation({ ReportForm });
 
     const reportId = selectedReport?.id;
 
-    type MutationParams = {
-        reportId: number;
-        body: Reply;
-    };
-
     const { data: repliesData } = useGetReportReplies(reportId);
     const repliesRes = useMemo(() => repliesData?.replies ?? [], [repliesData]);
-    const mutation = useMutation<Reply[] | null, Error, MutationParams>({
-        mutationFn: ({ reportId, body }) => postReportsReply(reportId, body),
-        onSuccess: (newReplies) => {
-            queryClient.invalidateQueries({ queryKey: ["reportReplies", reportId] });
-            setContent("");
-            setIsChecked({});
-            setSelectedReport(selectedReport);
-            if (newReplies && newReplies.length > 0) {
-                setReplies([...(repliesData?.replies ?? []), ...newReplies]);
-            }
-        },
-    });
 
     useEffect(() => {
         setSelectedReport(selectedReport);
@@ -274,7 +248,6 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     if (!community) return;
     return (
         <>
-            REPORTFORM
             <div className="report-drawer">
                 {loading && <LoaderComponent />}
                 <h2 className="ri-map-pin-add-line fr-mt-4v fr-mb-1v fr-text--md">
@@ -295,7 +268,7 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
                         }, 100);
                     }}
                 >
-                    Répondre
+                    {t("report_reply")}
                 </Button>
                 <div className="fr-mt-12v">
                     <Accordion label={t("select_theme")} defaultExpanded={false}>
@@ -399,86 +372,7 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
                         }}
                         expanded={openSuivi}
                     >
-                        <div className="report-drawer_tracking fr-mx-3v">
-                            {repliesRes.map((reply) => {
-                                const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
-                                return (
-                                    <div
-                                        key={reply.id}
-                                        className={`report-drawer_trackingItem  ${reply?.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
-                                    >
-                                        {reply?.author?.username === user?.name ? (
-                                            <p>
-                                                {reply?.author?.username}
-                                                <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
-                                            </p>
-                                        ) : (
-                                            <p>
-                                                <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply?.author?.username}
-                                            </p>
-                                        )}
-
-                                        <p className="report-drawer_trackingItem_date"> {reply.date}</p>
-                                        <p> {reply.content}</p>
-                                        <div className="report-drawer_trackingItem_status">
-                                            Statut:
-                                            <Badge
-                                                noIcon={hideIcon}
-                                                severity={reportImgStatus[reply.status as StatusKey].colorType as Severity}
-                                                className="fr-ml-2v"
-                                            >
-                                                {reply.status}
-                                            </Badge>
-                                        </div>
-                                    </div>
-                                );
-                            })}
-                        </div>
-                        <div>
-                            <form className="report-drawer_status fr-mt-6v">
-                                <Select
-                                    label={t("report_status")}
-                                    nativeSelectProps={{
-                                        onChange: (event) => setStatus(event.target.value),
-                                        value: status,
-                                    }}
-                                >
-                                    <React.Fragment key=".0">
-                                        {selectedReport && <option value={-1}>{reportImgStatus[selectedReport.status]?.text || ""}</option>}
-
-                                        {Object.keys(reportImgStatus).map((key) => {
-                                            const statusKey = key as StatusKey;
-                                            return (
-                                                <option key={statusKey} value={key}>
-                                                    {reportImgStatus[statusKey].text}
-                                                </option>
-                                            );
-                                        })}
-                                    </React.Fragment>
-                                </Select>
-                                <Input
-                                    label={t("report_content")}
-                                    textArea
-                                    nativeTextAreaProps={{
-                                        onChange: (event) => setContent(event.target.value),
-                                        value: content,
-                                    }}
-                                />
-                                <Button
-                                    onClick={async (e) => {
-                                        e.preventDefault();
-
-                                        if (reportId !== undefined) {
-                                            setCommittedStatus(status);
-                                            mutation.mutate({ reportId, body: { title: "Could be empty !", content, status } });
-                                        }
-                                    }}
-                                    className="fr-mt-4v"
-                                >
-                                    {t("report_send")}
-                                </Button>
-                            </form>
-                        </div>
+                        <ReportTracking setCommittedStatus={setCommittedStatus} />
                     </Accordion>
 
                     {!selectedReport && t("report_note")}

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -1,15 +1,15 @@
 import LoaderComponent from "@/components/LoaderComponent";
 import { CommunityTheme } from "@/constants/communities/types";
-import { ClickedTool, ErrorFile, PostThemeReport, ReportTool } from "@/constants/reports/types";
-import { useCommunityStore, useMapStore, useModalStore, useReportStore } from "@/store";
+import { ClickedTool, ErrorFile, PostThemeReport, Reply, ReportTool, Severity, StatusKey } from "@/constants/reports/types";
+import { useCommunityStore, useMapStore, useModalStore, useReportStore, useUserStore } from "@/store";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { Upload } from "@codegouvfr/react-dsfr/Upload";
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ThemeForm from "./ThemeForm";
-import { getThemeAttributes } from "@/constants/utils";
+import { getThemeAttributes, reportImgStatus } from "@/constants/utils";
 import DrawingForm from "./DrawingForm";
 import { Feature } from "ol";
 import CenterReport from "../CenterReport";
@@ -17,6 +17,15 @@ import ConfirmCancelModal from "./ConfirmCancelModal";
 import AttachmentList from "./AttachmentList";
 import { useTranslation } from "@/i18n";
 import useReportTools from "@/hooks/reports/useReportTools";
+import ReportFiltersComponent from "@/components/ReportFiltersComponent";
+import Badge from "@codegouvfr/react-dsfr/Badge";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postReportsReply } from "@/api/reportsData";
+import Select from "@codegouvfr/react-dsfr/Select";
+import React from "react";
+import { useGetReportReplies } from "@/api/repliesData";
+import { useRepliesStore } from "@/store/userRepliesStore";
+// import CreateTableData from "../table/CreateTableData";
 
 const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
 const maxSizeMB = 3;
@@ -35,6 +44,12 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     const [filesUploaded, setFilesUploaded] = useState<File[]>([]);
     const [clickedTool, setClickedTool] = useState<ClickedTool>({ name: "", clicked: false });
 
+    const [openSuivi, setOpenSuivi] = useState(false);
+    const [status, setStatus] = useState("");
+    const [content, setContent] = useState("");
+
+    const accordionRef = useRef<HTMLDivElement>(null);
+
     const [expendedDrawing, setExpendedDrawing] = useState<boolean>(false);
     const [expendedDescription, setExpendedDescription] = useState<boolean>(false);
     const [expendedDocument, setExpendedDocument] = useState<boolean>(false);
@@ -46,15 +61,58 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     const filesRef = useRef<HTMLDivElement>(null);
 
     const [loading, setLoading] = useState<boolean>(false);
+    const [committedStatus, setCommittedStatus] = useState("");
+
+    const queryClient = useQueryClient();
 
     const { community } = useCommunityStore();
-    const { editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened } = useReportStore();
+    const {
+        // filteredReports,
+        setSelectedReport,
+        // isChecked,
+        reports,
+        setIsChecked,
+        editReport,
+        selectedReport,
+        selectedFeatures,
+        setSelectedFeatures,
+        setTableDrawerOpened,
+    } = useReportStore();
 
     const reportTools = useReportTools();
     const { confirmCancelModal } = useModalStore();
     const { setClickedControl } = useMapStore();
+    const { setReplies } = useRepliesStore();
+    const { user } = useUserStore();
 
     const { t } = useTranslation({ ReportForm });
+
+    const reportId = selectedReport?.id;
+
+    type MutationParams = {
+        reportId: number;
+        body: Reply;
+    };
+
+    const { data: repliesData } = useGetReportReplies(reportId);
+    const repliesRes = useMemo(() => repliesData?.replies ?? [], [repliesData]);
+    const mutation = useMutation<Reply[] | null, Error, MutationParams>({
+        mutationFn: ({ reportId, body }) => postReportsReply(reportId, body),
+        onSuccess: (newReplies) => {
+            queryClient.invalidateQueries({ queryKey: ["reportReplies", reportId] });
+            setContent("");
+            setIsChecked({});
+            setSelectedReport(selectedReport);
+            if (newReplies && newReplies.length > 0) {
+                setReplies([...(repliesData?.replies ?? []), ...newReplies]);
+                // setReplies(newReplies);
+            }
+        },
+    });
+
+    useEffect(() => {
+        setSelectedReport(selectedReport);
+    }, [reports, selectedReport, setSelectedReport]);
 
     const handleToolClick = useCallback((tool: ReportTool | undefined) => {
         if (!tool) return;
@@ -226,130 +284,241 @@ const ReportForm: React.FC<Props> = ({ handleSubmit, handleDelete, handleClose }
     };
 
     if (!community) return;
-
     return (
         <>
+            REPORTFORM
             <div className="report-drawer">
                 {loading && <LoaderComponent />}
-                <h2 className="fr-mt-4v fr-mb-1v fr-text--md">
+                <h2 className="ri-map-pin-add-line fr-mt-4v fr-mb-1v fr-text--md">
                     {selectedReport ? t("edit_report_title", { reportId: selectedReport.id }) : t("create_report_title")}
                 </h2>
+                {selectedReport && <ReportFiltersComponent reportStatus={committedStatus} />}
                 {!selectedReport && (
                     <p className={`fr-text--sm fr-mb-1v ${selectedFeatures && !selectedFeatures.length ? "fr-message--error" : ""}`}>
                         {t("localize_report_alert")}
                     </p>
                 )}
 
-                <RadioButtons
-                    ref={themeRef}
-                    legend={t("select_theme")}
-                    options={community.themes.map((theme) => {
-                        return {
-                            label: theme.theme,
-                            nativeInputProps: {
-                                checked: selectedTheme?.theme === theme.theme,
-                                onClick: () => {
-                                    setSelectedTheme(theme);
-                                    setThemeAttributes(getThemeAttributes(theme));
-
-                                    setErrorTheme(() => "");
-                                },
-                                required: true,
-                            },
-                        };
-                    })}
-                    state={errorTheme ? "error" : selectedTheme ? "success" : "default"}
-                    stateRelatedMessage={errorTheme ?? ""}
-                    orientation="horizontal"
-                    small
-                    className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
-                />
-
-                {selectedTheme && <ThemeForm theme={selectedTheme} themeAttributes={themeAttributes} onChangeThemeAttributes={onChangeThemeAttributes} />}
-
-                <Accordion
-                    label={t("draw_sketch")}
-                    onExpandedChange={() => {
-                        setExpendedDrawing(!expendedDrawing);
+                <Button
+                    onClick={() => {
+                        setOpenSuivi(true);
+                        setTimeout(() => {
+                            accordionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                        }, 100);
                     }}
-                    expanded={expendedDrawing}
                 >
-                    <DrawingForm clickedTool={clickedTool} handleToolClick={handleToolClick} />
-                </Accordion>
-                <Accordion
-                    label={t("describe_report")}
-                    onExpandedChange={() => {
-                        setExpendedDescription(!expendedDescription);
-                    }}
-                    expanded={expendedDescription}
-                >
-                    <Input
-                        label={t("describe_report_label")}
-                        textArea
-                        nativeTextAreaProps={{
-                            value: description,
-                            rows: 5,
-                            onChange: (e) => {
-                                setDescription(e.target.value);
-                            },
+                    Répondre
+                </Button>
+                <div className="fr-mt-12v">
+                    <Accordion label={t("select_theme")} defaultExpanded={false}>
+                        <RadioButtons
+                            ref={themeRef}
+                            legend={t("select_theme")}
+                            options={community.themes.map((theme) => {
+                                return {
+                                    label: theme.theme,
+                                    nativeInputProps: {
+                                        checked: selectedTheme?.theme === theme.theme,
+                                        onClick: () => {
+                                            setSelectedTheme(theme);
+                                            setThemeAttributes(getThemeAttributes(theme));
+
+                                            setErrorTheme(() => "");
+                                        },
+                                        required: true,
+                                    },
+                                };
+                            })}
+                            state={errorTheme ? "error" : selectedTheme ? "success" : "default"}
+                            stateRelatedMessage={errorTheme ?? ""}
+                            orientation="horizontal"
+                            small
+                            className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
+                        />
+                        {selectedTheme && (
+                            <ThemeForm theme={selectedTheme} themeAttributes={themeAttributes} onChangeThemeAttributes={onChangeThemeAttributes} />
+                        )}
+                    </Accordion>
+
+                    <Accordion
+                        label={t("draw_sketch")}
+                        onExpandedChange={() => {
+                            setExpendedDrawing(!expendedDrawing);
                         }}
-                    />
-                </Accordion>
-
-                <Accordion
-                    label={t("import_attachments")}
-                    onExpandedChange={() => {
-                        setExpendedDocument(!expendedDocument);
-                    }}
-                    expanded={expendedDocument}
-                >
-                    <div
-                        style={{
-                            width: "100%",
-                        }}
+                        expanded={expendedDrawing}
                     >
-                        <Upload
-                            ref={filesRef}
-                            label={t("import_attachments_label")}
-                            hint={t("import_attachments_hint", { maxSizeMB })}
-                            state={errorFiles.length ? "error" : filesUploaded.length ? "success" : "default"}
-                            stateRelatedMessage=""
-                            multiple
-                            className="upload-file"
-                            nativeInputProps={{
-                                value: "",
-                                accept: ".jpg,.png,.pdf",
-                                onChange: (e) => onUploadChange(e),
+                        <DrawingForm clickedTool={clickedTool} handleToolClick={handleToolClick} />
+                    </Accordion>
+
+                    <Accordion
+                        label={t("describe_report")}
+                        onExpandedChange={() => {
+                            setExpendedDescription(!expendedDescription);
+                        }}
+                        expanded={expendedDescription}
+                    >
+                        <Input
+                            label={t("describe_report_label")}
+                            textArea
+                            nativeTextAreaProps={{
+                                value: description,
+                                rows: 5,
+                                onChange: (e) => {
+                                    setDescription(e.target.value);
+                                },
                             }}
                         />
-                        <AttachmentList newFiles={filesUploaded} errorFiles={errorFiles} removeFile={removeFile} />
-                    </div>
-                </Accordion>
-                {!selectedReport && t("report_note")}
+                    </Accordion>
 
-                {!selectedReport ? (
-                    <div className="submit">
-                        <Button size="large" onClick={onSubmit}>
-                            {t("submit_report")}
-                        </Button>
-                        <Button nativeButtonProps={confirmCancelModal.buttonProps} priority="tertiary" title="Annuler">
-                            {t("cancel_report")}
-                        </Button>
-                    </div>
-                ) : (
-                    <div className="buttons">
-                        <Button priority="secondary" onClick={onDelete}>
-                            {t("delete_report")}
-                        </Button>
-                        <Button priority="secondary" onClick={onClose}>
-                            {t("cancel_report")}
-                        </Button>
-                        <Button onClick={onSubmit}>{t("save_report")}</Button>
-                    </div>
-                )}
+                    <Accordion
+                        label={t("import_attachments")}
+                        onExpandedChange={() => {
+                            setExpendedDocument(!expendedDocument);
+                        }}
+                        expanded={expendedDocument}
+                    >
+                        <div
+                            style={{
+                                width: "100%",
+                            }}
+                        >
+                            <Upload
+                                ref={filesRef}
+                                label={t("import_attachments_label")}
+                                hint={t("import_attachments_hint", { maxSizeMB })}
+                                state={errorFiles.length ? "error" : filesUploaded.length ? "success" : "default"}
+                                stateRelatedMessage=""
+                                multiple
+                                className="upload-file"
+                                nativeInputProps={{
+                                    value: "",
+                                    accept: ".jpg,.png,.pdf",
+                                    onChange: (e) => onUploadChange(e),
+                                }}
+                            />
+                            <AttachmentList newFiles={filesUploaded} errorFiles={errorFiles} removeFile={removeFile} />
+                        </div>
+                    </Accordion>
+
+                    <Accordion
+                        ref={accordionRef}
+                        label={t("report_tracking")}
+                        onExpandedChange={(expanded: boolean) => {
+                            setOpenSuivi(expanded);
+                            if (expanded) {
+                                setReplies(repliesRes);
+                            }
+                        }}
+                        expanded={openSuivi}
+                    >
+                        <div className="report-drawer_tracking fr-mx-3v">
+                            {repliesRes.map((reply) => {
+                                const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
+                                return (
+                                    <div
+                                        key={reply.id}
+                                        className={`report-drawer_trackingItem  ${reply?.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
+                                    >
+                                        {reply?.author?.username === user?.name ? (
+                                            <p>
+                                                {reply?.author?.username}
+                                                <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
+                                            </p>
+                                        ) : (
+                                            <p>
+                                                <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply?.author?.username}
+                                            </p>
+                                        )}
+
+                                        <p className="report-drawer_trackingItem_date"> {reply.date}</p>
+                                        <p> {reply.content}</p>
+                                        <div className="report-drawer_trackingItem_status">
+                                            Statut:
+                                            <Badge
+                                                noIcon={hideIcon}
+                                                severity={reportImgStatus[reply.status as StatusKey].colorType as Severity}
+                                                className="fr-ml-2v"
+                                            >
+                                                {reply.status}
+                                            </Badge>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                        <div>
+                            <form className="report-drawer_status fr-mt-6v">
+                                <Select
+                                    label={t("report_status")}
+                                    nativeSelectProps={{
+                                        onChange: (event) => setStatus(event.target.value),
+                                        value: status,
+                                    }}
+                                >
+                                    <React.Fragment key=".0">
+                                        {selectedReport && <option value={-1}>{reportImgStatus[selectedReport.status]?.text || ""}</option>}
+
+                                        {Object.keys(reportImgStatus).map((key) => {
+                                            const statusKey = key as StatusKey;
+                                            return (
+                                                <option key={statusKey} value={key}>
+                                                    {reportImgStatus[statusKey].text}
+                                                </option>
+                                            );
+                                        })}
+                                    </React.Fragment>
+                                </Select>
+                                <Input
+                                    label={t("report_content")}
+                                    textArea
+                                    nativeTextAreaProps={{
+                                        onChange: (event) => setContent(event.target.value),
+                                        value: content,
+                                    }}
+                                />
+                                <Button
+                                    onClick={async (e) => {
+                                        e.preventDefault();
+
+                                        if (reportId !== undefined) {
+                                            setCommittedStatus(status);
+                                            mutation.mutate({ reportId, body: { title: "Could be empty !", content, status } });
+                                        }
+                                    }}
+                                    className="fr-mt-4v"
+                                >
+                                    {t("report_send")}
+                                </Button>
+                            </form>
+                        </div>
+                    </Accordion>
+
+                    {!selectedReport && t("report_note")}
+
+                    {!selectedReport ? (
+                        <div className="submit">
+                            <Button size="large" onClick={onSubmit}>
+                                {t("submit_report")}
+                            </Button>
+                            <Button nativeButtonProps={confirmCancelModal.buttonProps} priority="tertiary" title="Annuler">
+                                {t("cancel_report")}
+                            </Button>
+                        </div>
+                    ) : (
+                        <div className="buttons">
+                            <Button priority="secondary" onClick={onDelete}>
+                                {t("delete_report")}
+                            </Button>
+                            <Button priority="secondary" onClick={onClose}>
+                                {t("cancel_report")}
+                            </Button>
+                            <Button onClick={onSubmit}>{t("save_report")}</Button>
+                        </div>
+                    )}
+                </div>
+                <CenterReport />
+                <ConfirmCancelModal onClose={onClose} />
             </div>
-            <CenterReport />
-            <ConfirmCancelModal onClose={onClose} />
         </>
     );
 };

--- a/src/features/reports/forms/locale/OpenReplyReportModal.locale.tsx
+++ b/src/features/reports/forms/locale/OpenReplyReportModal.locale.tsx
@@ -7,6 +7,7 @@ export const OpenReplyReportModalFrTranslations: Translations<"fr">["OpenReplyRe
     replayStatus_text: "Statut",
     replayContent_text: "Description ",
     send_report: "Envoyer",
+    select_status: "Séléctionner un statut",
     back_to_reports: "Retour aux signalements",
     status_submit: "Reçu dans nos services",
     status_pending0: "En demande de qualification",
@@ -26,6 +27,7 @@ export const OpenReplyReportModalEnTranslations: Translations<"en">["OpenReplyRe
     replayStatus_text: "Status",
     replayContent_text: "Description",
     send_report: "Send",
+    select_status: "Select a status",
     back_to_reports: "Return to reports list",
     status_submit: "Received in our services",
     status_pending0: "Requesting qualification",
@@ -45,6 +47,7 @@ const { i18n } = declareComponentKeys<
     | "replayStatus_text"
     | "replayContent_text"
     | "send_report"
+    | "select_status"
     | "back_to_reports"
     | "status_submit"
     | "status_pending0"

--- a/src/features/reports/forms/locale/ReportForm.locale.tsx
+++ b/src/features/reports/forms/locale/ReportForm.locale.tsx
@@ -31,6 +31,10 @@ export const ReportFormFrTranslations: Translations<"fr">["ReportForm"] = {
     select_theme_error_message: "Vous devez obligatoirement choisir un thème et ses attributs pour envoyer un signalement",
     import_file_error_message_type: `Formats supportés : JPG, PNG, PDF`,
     import_file_error_message_size: ({ maxSizeMB }: { maxSizeMB: number }) => `Taille maximale : ${maxSizeMB} Mo.`,
+    report_tracking: "Suivi",
+    report_status: "Statut",
+    report_content: "Votre message",
+    report_send: "Envoyer",
 };
 
 export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
@@ -62,6 +66,10 @@ export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
     select_theme_error_message: "You must choose a theme and its attributes to send a report",
     import_file_error_message_type: "Supported formats: JPG, PNG, PDF",
     import_file_error_message_size: ({ maxSizeMB }: { maxSizeMB: number }) => `Maximum size: ${maxSizeMB} MB.`,
+    report_tracking: "Tracking",
+    report_status: "Status",
+    report_content: "Your message",
+    report_send: "Send",
 };
 
 const { i18n } = declareComponentKeys<
@@ -85,5 +93,9 @@ const { i18n } = declareComponentKeys<
     | "select_theme_error_message"
     | "import_file_error_message_type"
     | { K: "import_file_error_message_size"; P: { maxSizeMB: number }; R: string }
+    | "report_tracking"
+    | "report_status"
+    | "report_content"
+    | "report_send"
 >()("ReportForm");
 export type I18n = typeof i18n;

--- a/src/features/reports/forms/locale/ReportForm.locale.tsx
+++ b/src/features/reports/forms/locale/ReportForm.locale.tsx
@@ -35,6 +35,7 @@ export const ReportFormFrTranslations: Translations<"fr">["ReportForm"] = {
     report_status: "Statut",
     report_content: "Votre message",
     report_send: "Envoyer",
+    report_reply: "Répondre",
 };
 
 export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
@@ -70,6 +71,7 @@ export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
     report_status: "Status",
     report_content: "Your message",
     report_send: "Send",
+    report_reply: "Reply",
 };
 
 const { i18n } = declareComponentKeys<
@@ -97,5 +99,6 @@ const { i18n } = declareComponentKeys<
     | "report_status"
     | "report_content"
     | "report_send"
+    | "report_reply"
 >()("ReportForm");
 export type I18n = typeof i18n;

--- a/src/features/reports/locale/ReportTracking.locale.tsx
+++ b/src/features/reports/locale/ReportTracking.locale.tsx
@@ -1,0 +1,17 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const ReportTrackingFrTranslations: Translations<"fr">["ReportTracking"] = {
+    report_status: "Statut",
+    report_content: "Votre message",
+    report_send: "Envoyer",
+};
+
+export const ReportTrackingEnTranslations: Translations<"en">["ReportTracking"] = {
+    report_status: "Status",
+    report_content: "Your message",
+    report_send: "Send",
+};
+
+const { i18n } = declareComponentKeys<"report_status" | "report_content" | "report_send">()("ReportTracking");
+export type I18n = typeof i18n;

--- a/src/features/reports/locale/ShowReport.locale.tsx
+++ b/src/features/reports/locale/ShowReport.locale.tsx
@@ -13,6 +13,7 @@ export const ShowReportFrTranslations: Translations<"fr">["ShowReport"] = {
     report_status: "Statut",
     report_content: "Votre message",
     report_send: "Envoyer",
+    report_reply: "Répondre",
 };
 
 export const ShowReportEnTranslations: Translations<"en">["ShowReport"] = {
@@ -27,6 +28,7 @@ export const ShowReportEnTranslations: Translations<"en">["ShowReport"] = {
     report_status: "Status",
     report_content: "Your message",
     report_send: "Send",
+    report_reply: "Reply",
 };
 
 const { i18n } = declareComponentKeys<
@@ -40,6 +42,7 @@ const { i18n } = declareComponentKeys<
     | "report_tracking"
     | "report_status"
     | "report_content"
+    | "report_reply"
     | "report_send"
 >()("ShowReport");
 export type I18n = typeof i18n;

--- a/src/features/reports/table/CreateTableData.tsx
+++ b/src/features/reports/table/CreateTableData.tsx
@@ -1,4 +1,5 @@
-import { CommunityReport } from "@/constants/reports/types";
+import { CommunityReport, StatusKey } from "@/constants/reports/types";
+import { reportImgStatus } from "@/constants/utils";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
@@ -16,7 +17,9 @@ const CreateTableData = (
         const date = report.opening_date ? new Date(report.opening_date).toLocaleDateString() : "-";
         const departement = report.commune ? `${report.commune.title} (${report.departement?.name})` : "-";
         const themes = report.attributes && report.attributes.length > 0 ? report.attributes.map((attr) => attr.theme || "").join(", ") : "-";
+
         const status = report.status || "-";
+        const statusText = reportImgStatus[status as StatusKey].text;
 
         return {
             id: report.id,
@@ -28,7 +31,7 @@ const CreateTableData = (
                 opening_date: date,
                 departement,
                 theme: themes,
-                status,
+                statusText,
             },
             row: [
                 <Checkbox
@@ -50,7 +53,7 @@ const CreateTableData = (
                 departement,
                 <Tag>{report.attributes && report.attributes.length > 0 ? report.attributes.map((attr) => attr.theme || "").join(", ") : "-"}</Tag>,
                 <Badge severity="info" noIcon>
-                    {report.status || "-"}
+                    {statusText || "-"}
                 </Badge>,
                 <div>
                     {onShowReport && (

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -236,7 +236,7 @@ const TableReport = () => {
                                 type="button"
                                 disabled={!isChecked || !Object.values(isChecked).some(Boolean)}
                             >
-                                répondre
+                                {t("report_reply")}
                             </Button>
                         </div>
                     </div>

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -6,7 +6,7 @@ import VectorSource from "ol/source/Vector";
 import { getTableReports } from "@/api/reportsData";
 import { useReportStore, useModalStore, useMapStore, useLocalStorageStore } from "@/store";
 import { useCommunityStore } from "@/store/useCommunityStore";
-import { handleShowOnMap, transformReportsToExportData } from "@/constants/utils";
+import { handleShowOnMap } from "@/constants/utils";
 import { REPORT_TABLE_LIMIT_OPTIONS, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import GetReportsLayer from "@/features/navigation/layers/GetReportsLayer";
 import { StatusMessage } from "@/constants/communities/types";
@@ -144,18 +144,23 @@ const TableReport = () => {
         [reportsToUse, isChecked, onCheckChange, onShowReportOnMap, onShowOnMap]
     );
 
+    const selectedLines = useMemo(() => {
+        if (!exportedData || !Array.isArray(exportedData.data)) return [];
+        return CreateTableData(exportedData.data, isChecked, onCheckChange, onShowReportOnMap, onShowOnMap);
+    }, [exportedData, isChecked, onCheckChange, onShowReportOnMap, onShowOnMap]);
+
     const checkedLines = useMemo(() => {
-        if (!Array.isArray(tableData) || !isChecked) return [];
-        return tableData.filter((res) => !!isChecked[String(res.id)]).map((res) => res);
-    }, [tableData, isChecked]);
+        if (!Array.isArray(selectedLines) || !isChecked) return [];
+        return selectedLines.filter((res) => !!isChecked[String(res.id)]).map((res) => res.exportData);
+    }, [selectedLines, isChecked]);
 
     const downloadedTable = useMemo(() => {
-        if (checkedLines.length > 0) return checkedLines.map((exp) => exp.exportData);
-        if (Array.isArray(exportedData?.data)) {
-            return transformReportsToExportData(exportedData.data).map((expData) => expData);
+        if (checkedLines.length > 0) return checkedLines.map((exp) => exp);
+        if (Array.isArray(selectedLines)) {
+            return selectedLines.map((expData) => expData.exportData);
         }
         return [];
-    }, [checkedLines, exportedData]);
+    }, [checkedLines, selectedLines]);
 
     const tableHeaderToLabel: Record<FilterHeaderKey, string> = {
         author: "Auteur",

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -18,6 +18,7 @@ import { CenterMessageEnTranslations } from "@/features/reports/locale/CenterMes
 import { CreateReportEnTranslations } from "@/features/reports/locale/CreateReport.locale";
 import { EditReportEnTranslations } from "@/features/reports/locale/EditReport.locale";
 import { ShowReportEnTranslations } from "@/features/reports/locale/ShowReport.locale";
+import { ReportTrackingEnTranslations } from "@/features/reports/locale/ReportTracking.locale";
 import { useGetReportsLayerEnTranslations } from "@/hooks/navigation/layers/locale/useGetReportsLayer.locale";
 import { useGetWFSLayerEnTranslations } from "@/hooks/navigation/layers/locale/useGetWFSLayer.locale";
 import { useGetWMSLayerEnTranslations } from "@/hooks/navigation/layers/locale/useGetWMSLayer.locale";
@@ -58,6 +59,7 @@ export const translations: Translations<"en"> = {
     CreateReport: CreateReportEnTranslations,
     EditReport: EditReportEnTranslations,
     ShowReport: ShowReportEnTranslations,
+    ReportTracking: ReportTrackingEnTranslations,
     useGetReportsLayer: useGetReportsLayerEnTranslations,
     useGetWFSLayer: useGetWFSLayerEnTranslations,
     useGetWMSLayer: useGetWMSLayerEnTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -18,6 +18,7 @@ import { CenterMessageFrTranslations } from "@/features/reports/locale/CenterMes
 import { CreateReportFrTranslations } from "@/features/reports/locale/CreateReport.locale";
 import { EditReportFrTranslations } from "@/features/reports/locale/EditReport.locale";
 import { ShowReportFrTranslations } from "@/features/reports/locale/ShowReport.locale";
+import { ReportTrackingFrTranslations } from "@/features/reports/locale/ReportTracking.locale";
 import { useGetReportsLayerFrTranslations } from "@/hooks/navigation/layers/locale/useGetReportsLayer.locale";
 import { useGetWFSLayerFrTranslations } from "@/hooks/navigation/layers/locale/useGetWFSLayer.locale";
 import { useGetWMSLayerFrTranslations } from "@/hooks/navigation/layers/locale/useGetWMSLayer.locale";
@@ -58,6 +59,7 @@ export const translations: Translations<"fr"> = {
     CreateReport: CreateReportFrTranslations,
     EditReport: EditReportFrTranslations,
     ShowReport: ShowReportFrTranslations,
+    ReportTracking: ReportTrackingFrTranslations,
     useGetReportsLayer: useGetReportsLayerFrTranslations,
     useGetWFSLayer: useGetWFSLayerFrTranslations,
     useGetWMSLayer: useGetWMSLayerFrTranslations,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -41,6 +41,7 @@ export type ComponentKey =
     | import("../features/reports/locale/CreateReport.locale").I18n
     | import("../features/reports/locale/EditReport.locale").I18n
     | import("../features/reports/locale/ShowReport.locale").I18n
+    | import("../features/reports/locale/ReportTracking.locale").I18n
     | import("../features/working-layer/forms/locale/ShowFeatureTypeForm.locale").I18n
     | import("../features/working-layer/modal/locale/ClickableFeaturesModal.locale").I18n
     | import("../hooks/navigation/layers/locale/useGetReportsLayer.locale").I18n

--- a/src/store/useReplyStore.ts
+++ b/src/store/useReplyStore.ts
@@ -4,7 +4,7 @@ interface RepliesStore {
     replies: Reply[];
     setReplies: (newReplies: Reply[]) => void;
 }
-export const useRepliesStore = create<RepliesStore>((set, get) => ({
+export const useReplyStore = create<RepliesStore>((set, get) => ({
     replies: [],
     setReplies: (newReplies, appendOnly = true) => {
         if (appendOnly) {

--- a/src/store/userRepliesStore.ts
+++ b/src/store/userRepliesStore.ts
@@ -1,0 +1,19 @@
+import { Reply } from "@/constants/reports/types";
+import { create } from "zustand";
+interface RepliesStore {
+    replies: Reply[];
+    setReplies: (newReplies: Reply[]) => void;
+}
+export const useRepliesStore = create<RepliesStore>((set, get) => ({
+    replies: [],
+    setReplies: (newReplies, appendOnly = true) => {
+        if (appendOnly) {
+            const oldReplies = get().replies;
+            const oldIds = new Set(oldReplies.map((r) => r.id));
+            const filteredNewReplies = newReplies.filter((r) => !oldIds.has(r.id));
+            set({ replies: [...oldReplies, ...filteredNewReplies] });
+        } else {
+            set({ replies: newReplies });
+        }
+    },
+}));


### PR DESCRIPTION
- Création d’une section "Suivi" permettant d’afficher les échanges et mises à jour liés à un signalement.

<img width="1920" height="932" alt="image" src="https://github.com/user-attachments/assets/812f0c37-2094-48fb-9699-621e51a3fa1f" />

Gestion de l’affichage du volet “Signalement” :
- Permettre la modification du contenu uniquement pour les administrateurs.
- Restreindre les droits d’édition pour les utilisateurs non administrateurs (lecture seule).

<img width="1850" height="932" alt="image" src="https://github.com/user-attachments/assets/504a0e00-5530-4490-a21b-19521b9833d5" />

<img width="1850" height="932" alt="image" src="https://github.com/user-attachments/assets/f28867ee-8fa8-4102-840d-8927a3d57204" />

- Gérer le scroll vers la section 'suivi' lorsqu'on clique sur 'répondre'
- Afficher l'jout d'un réponse en temps réél sur le tableau des signalements