### PR TITLE
Feat/afficher un signalement  update

### DIFF
--- a/src/components/DrawerComponent.tsx
+++ b/src/components/DrawerComponent.tsx
@@ -1,6 +1,4 @@
 import { APP_FOOTER_MIN_HEIGHT } from "@/constants";
-import { useTranslation } from "@/i18n";
-import Button from "@codegouvfr/react-dsfr/Button";
 import MuiDsfrThemeProvider from "@codegouvfr/react-dsfr/mui";
 import Drawer from "@mui/material/Drawer";
 import { JSX } from "react";
@@ -19,7 +17,6 @@ const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, onClose })
     const mapToolbarHeader = document.getElementById("map-toolbar-header");
     const headerHeight = (mapToolbarHeader?.clientHeight || 0) + APP_FOOTER_MIN_HEIGHT;
 
-    const { t } = useTranslation({ DrawerComponent });
     return (
         <MuiDsfrThemeProvider>
             <Drawer
@@ -36,18 +33,6 @@ const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, onClose })
                     },
                 }}
             >
-                <div className="drawer-close">
-                    <Button
-                        className="fr-icon--lg"
-                        iconId="ri-close-line"
-                        onClick={onClose}
-                        priority="tertiary no outline"
-                        title={t("button_title")}
-                        size="medium"
-                    >
-                        {t("button_title")}
-                    </Button>
-                </div>
                 <div className="drawer-content" style={{ height: `calc(100vh - 40px - ${headerHeight}px)`, overflow: "auto" }}>
                     {children}
                 </div>

--- a/src/components/DrawerComponent.tsx
+++ b/src/components/DrawerComponent.tsx
@@ -15,7 +15,7 @@ interface Props {
     onClose: () => void;
 }
 
-const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, create, onClose }) => {
+const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, onClose }) => {
     const mapToolbarHeader = document.getElementById("map-toolbar-header");
     const headerHeight = (mapToolbarHeader?.clientHeight || 0) + APP_FOOTER_MIN_HEIGHT;
 
@@ -37,7 +37,16 @@ const DrawerComponent: React.FC<Props> = ({ anchor, isOpen, children, create, on
                 }}
             >
                 <div className="drawer-close">
-                    {!create && <Button iconId="ri-close-line" onClick={onClose} priority="tertiary no outline" title={t("button_title")} />}
+                    <Button
+                        className="fr-icon--lg"
+                        iconId="ri-close-line"
+                        onClick={onClose}
+                        priority="tertiary no outline"
+                        title={t("button_title")}
+                        size="medium"
+                    >
+                        {t("button_title")}
+                    </Button>
                 </div>
                 <div className="drawer-content" style={{ height: `calc(100vh - 40px - ${headerHeight}px)`, overflow: "auto" }}>
                     {children}

--- a/src/components/ModaleComponent.tsx
+++ b/src/components/ModaleComponent.tsx
@@ -14,17 +14,14 @@ const ModaleComponent: React.FC<ModaleProps> = ({ title, children, modal, onConf
     return (
         <modal.Component
             title={title}
-            iconId="fr-icon-info-fill"
             buttons={[
                 {
-                    iconId: "ri-check-line",
-                    onClick: onConfirm,
-                    children: confirmText,
-                },
-                {
-                    iconId: "ri-close-line",
                     onClick: onClose,
                     children: cancelText,
+                },
+                {
+                    onClick: onConfirm,
+                    children: confirmText,
                 },
             ]}
         >

--- a/src/constants/reports/types.ts
+++ b/src/constants/reports/types.ts
@@ -73,6 +73,10 @@ export interface CommunityReport {
     author?: AuthorData;
     attributes?: CommunityTheme[];
 }
+export enum SortType {
+    ASC = "ASC",
+    DESC = "DESC",
+}
 
 export type Reply = {
     id?: number;

--- a/src/constants/reports/utils/SortByDateCreation.ts
+++ b/src/constants/reports/utils/SortByDateCreation.ts
@@ -1,0 +1,9 @@
+import { CommunityReport } from "../types";
+
+export function getSortByDateCreation(reports: CommunityReport[], order: "ASC" | "DESC") {
+    return [...reports].sort((a, b) => {
+        const dateA = a.opening_date ? new Date(a.opening_date).getTime() : 0;
+        const dateB = b.opening_date ? new Date(b.opening_date).getTime() : 0;
+        return order === "ASC" ? dateA - dateB : dateB - dateA;
+    });
+}

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -77,6 +77,7 @@ export const reportImgStatus: ReportImgStatusType = {
     test: { img: imgTest, text: "En mode test", colorType: "new" },
 };
 
+export const STATUS_NOT_ALLOWED = ["valid", "valid0", "reject", "test"];
 type LonLatCoordinate = Coordinate | Coordinate[] | Coordinate[][] | Coordinate[][][];
 type FeatureTypeData = { geometrie: string; capacite: number | null; type_amenagement: string | null };
 

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -12,3 +12,4 @@
 @import url("./review-contributions.css");
 @import url("./custom-controls.css");
 @import url("./contribution-list.css");
+@import url("./report-deleteShare.css");

--- a/src/css/report-deleteShare.css
+++ b/src/css/report-deleteShare.css
@@ -1,0 +1,34 @@
+.report-deleteShare {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+.report-deleteShare__wrapper {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.04);
+}
+.report-deleteShare__container {
+    position: absolute;
+    top: 0;
+    right: 40px;
+    box-shadow: 0px 2px 6px 0px var(--shadow-color);
+}
+.report-deleteShare__container > button {
+    position: relative;
+    display: block;
+    background-color: #fff;
+    width: 100%;
+}
+.report-deleteShare__container > button:first-child::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    width: calc(100% - 8px);
+    height: 1px;
+    background: rgba(221, 221, 221, 1);
+}

--- a/src/css/report.css
+++ b/src/css/report.css
@@ -182,7 +182,6 @@
 
 .report-attachments {
     margin-top: 10px;
-    margin-bottom: 25px;
 }
 .report-attachments div {
     display: flex;

--- a/src/css/report.css
+++ b/src/css/report.css
@@ -147,8 +147,14 @@
 }
 
 .report-drawer {
+    position: relative;
     width: 588px;
     padding: 10px 16px;
+}
+
+.report-drawer__container {
+    position: relative;
+    display: flex;
 }
 
 .report-drawer .note {

--- a/src/css/report.css
+++ b/src/css/report.css
@@ -243,7 +243,6 @@
     display: flex;
     flex-direction: column;
     margin-top: 25px;
-    /* margin-bottom: 25px; */
     gap: 5px;
 }
 

--- a/src/css/report.css
+++ b/src/css/report.css
@@ -238,7 +238,7 @@
     display: flex;
     flex-direction: column;
     margin-top: 25px;
-    margin-bottom: 25px;
+    /* margin-bottom: 25px; */
     gap: 5px;
 }
 

--- a/src/css/show-report.css
+++ b/src/css/show-report.css
@@ -46,11 +46,17 @@
 .report-drawer_status {
     display: flex;
     flex-direction: column;
-    padding: 16px 0px;
-    border-top: 1px solid var(--grey-900-175);
-    border-top-style: dashed;
+    padding: 25px 0px;
+    margin-bottom: 20px;
+    border-bottom: 1px solid var(--grey-900-175);
+    border-bottom-style: dashed;
 }
 
 .report-drawer_status > button {
     align-self: flex-end;
+}
+.report__actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 30px;
 }

--- a/src/features/reports/ConfirmDeleteShareReportModal.tsx
+++ b/src/features/reports/ConfirmDeleteShareReportModal.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from "@/i18n";
+import { useModalStore } from "@/store";
+
+import ModaleComponent from "@/components/ModaleComponent";
+interface Props {
+    handleDelete: () => void;
+}
+const ConfirmDeleteShareReportModal = ({ handleDelete }: Props) => {
+    const { t } = useTranslation({ ConfirmDeleteShareReportModal });
+
+    const { deleteShareReportModal } = useModalStore();
+
+    return (
+        <ModaleComponent
+            modal={deleteShareReportModal}
+            title={t("deleteReports_title")}
+            onClose={() => null}
+            onConfirm={() => handleDelete()}
+            cancelText={t("cancel_btn")}
+            confirmText={t("delete_btn")}
+        >
+            <p>{t("deleteReport_message")}</p>
+        </ModaleComponent>
+    );
+};
+
+export default ConfirmDeleteShareReportModal;

--- a/src/features/reports/DeleteShareReportComponent.tsx
+++ b/src/features/reports/DeleteShareReportComponent.tsx
@@ -1,0 +1,34 @@
+import Button from "@codegouvfr/react-dsfr/Button";
+import { useState } from "react";
+import ConfirmDeleteShareReportModal from "./ConfirmDeleteShareReportModal";
+import { useModalStore } from "@/store";
+// import "../../css/report-deleteShare.css";
+interface Props {
+    handleDelete: () => void;
+}
+const DeleteShareReportComponent = ({ handleDelete }: Props) => {
+    const [showActions, setShowActions] = useState<boolean>(false);
+    const { deleteShareReportModal } = useModalStore();
+    return (
+        <div className="report-deleteShare__wrapper">
+            <Button
+                iconId="ri-more-2-line"
+                className="btn-show-actions fr-btn fr-btn--tertiary-no-outline"
+                title="Afficher les actions"
+                onClick={() => setShowActions(!showActions)}
+            />
+
+            {showActions && (
+                <div className="report-deleteShare__container">
+                    <Button priority="tertiary no outline" nativeButtonProps={deleteShareReportModal.buttonProps}>
+                        Supprimer
+                    </Button>
+                    <Button priority="tertiary no outline">Partager</Button>
+                </div>
+            )}
+            <ConfirmDeleteShareReportModal handleDelete={handleDelete} />
+        </div>
+    );
+};
+
+export default DeleteShareReportComponent;

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -10,6 +10,7 @@ import { clearDrawingLayer, getFeatureGeometryWKT } from "@/constants/utils";
 import { getReportSketch, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import ReportForm from "./forms/ReportForm";
 import { useCallback } from "react";
+import Button from "@codegouvfr/react-dsfr/Button";
 
 interface Props {
     handleCloseDrawer: () => void;
@@ -17,7 +18,7 @@ interface Props {
 
 const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const { community, addAlertMessage } = useCommunityStore();
-    const { reports, selectedReport, setReports, setTableDrawerOpened } = useReportStore();
+    const { reports, selectedReport, setReports, setTableDrawerOpened, setDrawerOpened } = useReportStore();
 
     const { map } = useMapStore();
 
@@ -167,6 +168,18 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
 
     return (
         <>
+            <Button
+                iconId="fr-icon-arrow-left-line"
+                className="fr-icon--sm fr-mr-7v"
+                priority="tertiary no outline"
+                title="Afficher le signalement"
+                onClick={() => {
+                    setTableDrawerOpened(true);
+                    setDrawerOpened(false);
+                }}
+            >
+                {t("report_back")}
+            </Button>
             <ReportForm
                 handleClose={handleCloseEditReportDrawer}
                 handleDelete={handleDeleteReport}

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -112,7 +112,13 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
             addAlertMessage(StatusMessage.success, t("report_deleted_success", { reportId: selectedReport.id }));
             const reportLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
             const reportSource = reportLayer?.getSource() as VectorSource;
-            reportSource.removeFeatures(reportSource.getFeatures().filter((f) => f.get("reportData").id === selectedReport.id));
+
+            const filteredFeatures = reportSource.getFeatures().filter((f) => {
+                const reportData = f.get("reportData");
+                return reportData?.id === selectedReport.id;
+            });
+
+            reportSource.removeFeatures(filteredFeatures);
             setReports([...reports.filter((report) => report.id !== selectedReport.id)], true);
             handleCloseDrawer();
             clearDrawingLayer(map);

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { useTranslation } from "@/i18n";
 import { Feature, MapBrowserEvent } from "ol";
 import Layer from "ol/layer/Layer";
 import VectorSource from "ol/source/Vector";
@@ -8,10 +7,9 @@ import { useGetUserProfileAPI } from "@/api/userData";
 import { useCommunityStore, useMapStore, useReportStore, useUserStore } from "@/store";
 import { HIT_DETECTION_TOLERENCE, FEATURE_TYPE_GEOSERVICE_PROPERTY } from "@/constants";
 import { getClickedMapReport, getReportSketchFeatures, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
-import { getCenterReportMessage, showCenterReportButtons } from "@/constants/utils";
+import { getCenterReportMessage, showCenterReportButtons, STATUS_NOT_ALLOWED } from "@/constants/utils";
 import { clearClusterStyles } from "@/constants/reports/utils/cluster";
 import { ParamsReport, toolNames } from "@/constants/reports/types";
-import Button from "@codegouvfr/react-dsfr/Button";
 import DrawerComponent from "@/components/DrawerComponent";
 import ShowReport from "./ShowReport";
 import CreateReport from "./CreateReport";
@@ -19,9 +17,10 @@ import TableReportDrawer from "./table/TableReportDrawer";
 import OpenReplyReportModal from "./forms/OpenReplyReportModal";
 import EditReport from "./EditReport";
 import { InteractionType } from "@/constants/communities/types";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { useTranslation } from "@/i18n";
 
 const ReportDrawer = () => {
-    const { t } = useTranslation({ ShowReport });
     const { mapWorkingLayer } = useMapStore();
     const { user } = useUserStore();
 
@@ -53,6 +52,7 @@ const ReportDrawer = () => {
     const { community } = useCommunityStore();
 
     const { data: userData } = useGetUserProfileAPI();
+    const { t } = useTranslation({ ReportDrawer });
 
     const handleCloseDrawer = useCallback(() => {
         if (!selectedReport) {
@@ -83,20 +83,23 @@ const ReportDrawer = () => {
 
         setDrawerOpened(false);
         setEditReport(false);
-        setTableDrawerOpened(!tableDrawerOpened && true);
+        if (editReport) {
+            setTableDrawerOpened(!tableDrawerOpened && true);
+        } else setTableDrawerOpened(false);
         setSelectedReport(null);
         setSelectedFeatures([]);
     }, [
-        map,
         selectedReport,
         alertMessages,
-        removeAlertMessage,
-        setEditReport,
-        setSelectedFeatures,
-        setSelectedReport,
         setDrawerOpened,
+        setEditReport,
+        editReport,
         setTableDrawerOpened,
         tableDrawerOpened,
+        setSelectedReport,
+        setSelectedFeatures,
+        map,
+        removeAlertMessage,
     ]);
 
     const handleSingleClick = useCallback(
@@ -312,21 +315,21 @@ const ReportDrawer = () => {
                 <>
                     {drawerOpened ? (
                         <>
-                            <Button
-                                iconId="fr-icon-arrow-left-line"
-                                className="fr-icon--sm fr-mr-7v"
-                                priority="tertiary no outline"
-                                title="Afficher le signalement"
-                                onClick={() => {
-                                    setTableDrawerOpened(true);
-                                    setDrawerOpened(false);
-                                }}
-                            >
-                                {t("report_back")}
-                            </Button>
+                            <div className="drawer-close">
+                                <Button
+                                    className="fr-icon--lg"
+                                    iconId="ri-close-line"
+                                    onClick={handleCloseDrawer}
+                                    priority="tertiary no outline"
+                                    title="Fermer"
+                                    size="medium"
+                                >
+                                    {t("close")}
+                                </Button>
+                            </div>
                             {!selectedReport ? (
                                 <CreateReport handleCloseDrawer={handleCloseDrawer} />
-                            ) : (["valid", "valid0", "reject", "test"].includes(status) ? false : isAdmin || isOwner) ? (
+                            ) : !STATUS_NOT_ALLOWED.includes(selectedReport.status) && (isAdmin || isOwner) ? (
                                 <EditReport handleCloseDrawer={handleCloseDrawer} />
                             ) : (
                                 <ShowReport handleCloseDrawer={handleCloseDrawer} />

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -326,7 +326,7 @@ const ReportDrawer = () => {
                             </Button>
                             {!selectedReport ? (
                                 <CreateReport handleCloseDrawer={handleCloseDrawer} />
-                            ) : isAdmin || isOwner ? (
+                            ) : (["valid", "valid0", "reject", "test"].includes(status) ? false : isAdmin || isOwner) ? (
                                 <EditReport handleCloseDrawer={handleCloseDrawer} />
                             ) : (
                                 <ShowReport handleCloseDrawer={handleCloseDrawer} />

--- a/src/features/reports/ReportTracking.tsx
+++ b/src/features/reports/ReportTracking.tsx
@@ -60,71 +60,83 @@ const ReportTracking: React.FC<ReportTrackingProps> = ({ setCommittedStatus }) =
     return (
         <>
             <div className="report-drawer_tracking fr-mx-3v">
-                {repliesRes.map((reply) => {
-                    const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
-                    return (
-                        <div
-                            key={reply.id}
-                            className={`report-drawer_trackingItem  ${reply.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
-                        >
-                            {reply.author?.username === user?.name ? (
-                                <p>
-                                    {reply.author?.username}
-                                    <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
-                                </p>
-                            ) : (
-                                <p>
-                                    <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply.author?.username}
-                                </p>
-                            )}
+                {repliesRes.length > 0 ? (
+                    repliesRes.map((reply) => {
+                        const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
+                        const formattedDate = reply.date
+                            ? new Date(reply.date).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" }) +
+                              ", " +
+                              new Date(reply.date).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit", hour12: false }).replace(":", "H")
+                            : "-";
 
-                            <p className="report-drawer_trackingItem_date"> {reply.date}</p>
-                            <p> {reply.content}</p>
-                            <div className="report-drawer_trackingItem_status">
-                                {t("report_status")}:
-                                <Badge noIcon={hideIcon} severity={reportImgStatus[reply.status as StatusKey].colorType as Severity} className="fr-ml-2v">
-                                    {reply.status}
-                                </Badge>
+                        return (
+                            <div
+                                key={reply.id}
+                                className={`report-drawer_trackingItem  ${reply.author?.username === user?.name ? "report-drawer_trackingItem--right" : ""}`}
+                            >
+                                {reply.author?.username === user?.name ? (
+                                    <p>
+                                        {reply.author?.username}
+                                        <span className="fr-icon-account-fill fr-ml-1v" aria-hidden="true"></span>
+                                    </p>
+                                ) : (
+                                    <p>
+                                        <span className="fr-icon-account-line fr-mr-1v" aria-hidden="true"></span> {reply.author?.username}
+                                    </p>
+                                )}
+
+                                <p className="report-drawer_trackingItem_date"> {formattedDate}</p>
+                                <p> {reply.content}</p>
+                                <div className="report-drawer_trackingItem_status">
+                                    {t("report_status")}:
+                                    <Badge noIcon={hideIcon} severity={reportImgStatus[reply.status as StatusKey].colorType as Severity} className="fr-ml-2v">
+                                        {reportImgStatus[reply.status as StatusKey].text}
+                                    </Badge>
+                                </div>
                             </div>
-                        </div>
-                    );
-                })}
+                        );
+                    })
+                ) : (
+                    <p> {t("no_reply")}</p>
+                )}
             </div>
-            <div>
-                <form className="report-drawer_status fr-mt-6v">
-                    <Select
-                        label={t("report_status")}
-                        nativeSelectProps={{
-                            onChange: (event) => setStatus(event.target.value),
-                            value: status,
-                        }}
-                    >
-                        <React.Fragment key=".0">
-                            <option value={-1}>{reportImgStatus[selectedReport?.status]?.text || ""}</option>
+            {!["valid", "valid0", "reject", "test"].includes(selectedReport?.status) && (
+                <>
+                    <form className="report-drawer_status fr-mt-6v">
+                        <Select
+                            label={t("report_status")}
+                            nativeSelectProps={{
+                                onChange: (event) => setStatus(event.target.value),
+                                value: status,
+                            }}
+                        >
+                            <React.Fragment key=".0">
+                                <option value={-1}>{reportImgStatus[selectedReport?.status]?.text || ""}</option>
 
-                            {Object.keys(reportImgStatus).map((key) => {
-                                const statusKey = key as StatusKey;
-                                return (
-                                    <option key={statusKey} value={key}>
-                                        {reportImgStatus[statusKey].text}
-                                    </option>
-                                );
-                            })}
-                        </React.Fragment>
-                    </Select>
-                    <Input
-                        label={t("report_content")}
-                        textArea
-                        nativeTextAreaProps={{
-                            onChange: (event) => setContent(event.target.value),
-                            value: content,
-                        }}
-                    />
-                    <Button onClick={onSubmitReply} className="fr-mt-4v">
-                        {t("report_send")}
-                    </Button>
-                </form>
-            </div>
+                                {Object.keys(reportImgStatus).map((key) => {
+                                    const statusKey = key as StatusKey;
+                                    return (
+                                        <option key={statusKey} value={key}>
+                                            {reportImgStatus[statusKey].text}
+                                        </option>
+                                    );
+                                })}
+                            </React.Fragment>
+                        </Select>
+                        <Input
+                            label={t("report_content")}
+                            textArea
+                            nativeTextAreaProps={{
+                                onChange: (event) => setContent(event.target.value),
+                                value: content,
+                            }}
+                        />
+                        <Button onClick={onSubmitReply} className="fr-mt-4v">
+                            {t("report_send")}
+                        </Button>
+                    </form>
+                </>
+            )}
         </>
     );
 };

--- a/src/features/reports/ReportTracking.tsx
+++ b/src/features/reports/ReportTracking.tsx
@@ -7,7 +7,7 @@ import { useGetReportReplies } from "@/api/repliesData";
 import { useCommunityStore, useReportStore, useUserStore } from "@/store";
 import { useReplyStore } from "@/store/useReplyStore";
 import { MutationReportParams, Reply, Severity, StatusKey } from "@/constants/reports/types";
-import { reportImgStatus } from "@/constants/utils";
+import { reportImgStatus, STATUS_NOT_ALLOWED } from "@/constants/utils";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Select from "@codegouvfr/react-dsfr/Select";
 import Input from "@codegouvfr/react-dsfr/Input";
@@ -59,9 +59,9 @@ const ReportTracking: React.FC<ReportTrackingProps> = ({ setCommittedStatus }) =
 
     return (
         <>
-            {!["valid", "valid0", "reject", "test"].includes(selectedReport?.status) && (
+            {!STATUS_NOT_ALLOWED.includes(selectedReport?.status) && (
                 <>
-                    <form className="report-drawer_status fr-mt-6v">
+                    <form className="report-drawer_status">
                         <Select
                             label={t("report_status")}
                             nativeSelectProps={{
@@ -90,21 +90,34 @@ const ReportTracking: React.FC<ReportTrackingProps> = ({ setCommittedStatus }) =
                                 value: content,
                             }}
                         />
-                        <Button onClick={onSubmitReply} className="fr-mt-4v">
+                        <Button
+                            disabled={!status || reportImgStatus[status as StatusKey]?.text === reportImgStatus[selectedReport?.status as StatusKey]?.text}
+                            onClick={onSubmitReply}
+                            className="fr-mt-4v"
+                        >
                             {t("report_send")}
                         </Button>
                     </form>
                 </>
             )}
-            <div className="report-drawer_tracking fr-mx-3v">
+            <div className="report-drawer_tracking fr-mx-7v">
                 {repliesRes.length > 0 ? (
                     repliesRes.map((reply) => {
                         const hideIcon = reportImgStatus[reply.status as StatusKey].text !== "test";
-                        const formattedDate = reply.date
-                            ? new Date(reply.date).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" }) +
-                              ", " +
-                              new Date(reply.date).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit", hour12: false }).replace(":", "H")
-                            : "-";
+                        const formatFrenchDateWithCapitalMonth = (dateStr: string) => {
+                            if (!dateStr) return "-";
+                            const d = new Date(dateStr);
+                            const day = d.getDate();
+                            const year = d.getFullYear();
+                            const month = d.toLocaleDateString("fr-FR", { month: "long" });
+                            const monthCapital = month.charAt(0).toUpperCase() + month.slice(1);
+
+                            const heure = d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit", hour12: false }).replace(":", "H");
+
+                            return `${day} ${monthCapital} ${year}, ${heure}`;
+                        };
+
+                        const formattedDate = reply.date ? formatFrenchDateWithCapitalMonth(reply.date) : "-";
 
                         return (
                             <div

--- a/src/features/reports/ReportTracking.tsx
+++ b/src/features/reports/ReportTracking.tsx
@@ -59,6 +59,43 @@ const ReportTracking: React.FC<ReportTrackingProps> = ({ setCommittedStatus }) =
 
     return (
         <>
+            {!["valid", "valid0", "reject", "test"].includes(selectedReport?.status) && (
+                <>
+                    <form className="report-drawer_status fr-mt-6v">
+                        <Select
+                            label={t("report_status")}
+                            nativeSelectProps={{
+                                onChange: (event) => setStatus(event.target.value),
+                                value: status,
+                            }}
+                        >
+                            <React.Fragment key=".0">
+                                <option value={-1}>{reportImgStatus[selectedReport?.status]?.text || ""}</option>
+
+                                {Object.keys(reportImgStatus).map((key) => {
+                                    const statusKey = key as StatusKey;
+                                    return (
+                                        <option key={statusKey} value={key}>
+                                            {reportImgStatus[statusKey].text}
+                                        </option>
+                                    );
+                                })}
+                            </React.Fragment>
+                        </Select>
+                        <Input
+                            label={t("report_content")}
+                            textArea
+                            nativeTextAreaProps={{
+                                onChange: (event) => setContent(event.target.value),
+                                value: content,
+                            }}
+                        />
+                        <Button onClick={onSubmitReply} className="fr-mt-4v">
+                            {t("report_send")}
+                        </Button>
+                    </form>
+                </>
+            )}
             <div className="report-drawer_tracking fr-mx-3v">
                 {repliesRes.length > 0 ? (
                     repliesRes.map((reply) => {
@@ -100,43 +137,6 @@ const ReportTracking: React.FC<ReportTrackingProps> = ({ setCommittedStatus }) =
                     <p> {t("no_reply")}</p>
                 )}
             </div>
-            {!["valid", "valid0", "reject", "test"].includes(selectedReport?.status) && (
-                <>
-                    <form className="report-drawer_status fr-mt-6v">
-                        <Select
-                            label={t("report_status")}
-                            nativeSelectProps={{
-                                onChange: (event) => setStatus(event.target.value),
-                                value: status,
-                            }}
-                        >
-                            <React.Fragment key=".0">
-                                <option value={-1}>{reportImgStatus[selectedReport?.status]?.text || ""}</option>
-
-                                {Object.keys(reportImgStatus).map((key) => {
-                                    const statusKey = key as StatusKey;
-                                    return (
-                                        <option key={statusKey} value={key}>
-                                            {reportImgStatus[statusKey].text}
-                                        </option>
-                                    );
-                                })}
-                            </React.Fragment>
-                        </Select>
-                        <Input
-                            label={t("report_content")}
-                            textArea
-                            nativeTextAreaProps={{
-                                onChange: (event) => setContent(event.target.value),
-                                value: content,
-                            }}
-                        />
-                        <Button onClick={onSubmitReply} className="fr-mt-4v">
-                            {t("report_send")}
-                        </Button>
-                    </form>
-                </>
-            )}
         </>
     );
 };

--- a/src/features/reports/ShowReport.tsx
+++ b/src/features/reports/ShowReport.tsx
@@ -11,6 +11,7 @@ import ReportFiltersComponent from "@/components/ReportFiltersComponent";
 import AttachmentList from "./forms/AttachmentList";
 import ReportTracking from "./ReportTracking";
 import DrawingForm from "./forms/DrawingForm";
+import { STATUS_NOT_ALLOWED } from "@/constants/utils";
 interface Props {
     handleCloseDrawer: () => void;
 }
@@ -61,16 +62,18 @@ const ShowReport: React.FC<Props> = () => {
                     {t("report_title", { reportId: selectedReport.id })}
                 </h2>
                 <ReportFiltersComponent reportStatus={committedStatus} />
-                <Button
-                    onClick={() => {
-                        setOpenSuivi(true);
-                        setTimeout(() => {
-                            accordionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-                        }, 100);
-                    }}
-                >
-                    {t("report_reply")}
-                </Button>
+                {!STATUS_NOT_ALLOWED.includes(selectedReport.status) && (
+                    <Button
+                        onClick={() => {
+                            setOpenSuivi(true);
+                            setTimeout(() => {
+                                accordionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                            }, 100);
+                        }}
+                    >
+                        {t("report_reply")}
+                    </Button>
+                )}
                 <div className="fr-mt-12v">
                     <Accordion label={t("report_theme")} defaultExpanded={false}>
                         <RadioButtons

--- a/src/features/reports/forms/AttachmentList.tsx
+++ b/src/features/reports/forms/AttachmentList.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) => {
     const { addAlertMessage } = useCommunityStore();
-    const { reports, selectedReport, setReports, isShowReport, editReport } = useReportStore();
+    const { reports, selectedReport, setReports, editReport } = useReportStore();
 
     const [loading, setLoading] = useState(false);
 
@@ -43,7 +43,7 @@ const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) =
     return (
         <div className="report-attachments">
             {loading && <LoaderComponent />}
-            {isShowReport() && !report?.attachments.length && <p>{t("no_attachments")}</p>}
+            {!report?.attachments.length && <p>{t("no_attachments")}</p>}
             {report &&
                 report.attachments.map((attachment) => (
                     <div key={`attachment_${attachment.id}`}>

--- a/src/features/reports/forms/AttachmentList.tsx
+++ b/src/features/reports/forms/AttachmentList.tsx
@@ -12,9 +12,10 @@ interface Props {
     newFiles?: File[] | null;
     errorFiles?: ErrorFile[];
     removeFile?: (file: File) => void;
+    showDocument?: boolean;
 }
 
-const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) => {
+const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile, showDocument }) => {
     const { addAlertMessage } = useCommunityStore();
     const { reports, selectedReport, setReports, editReport } = useReportStore();
 
@@ -43,7 +44,7 @@ const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) =
     return (
         <div className="report-attachments">
             {loading && <LoaderComponent />}
-            {!report?.attachments.length && <p>{t("no_attachments")}</p>}
+            {!report?.attachments?.length && <p>{t("no_attachments")}</p>}
             {report &&
                 report.attachments.map((attachment) => (
                     <div key={`attachment_${attachment.id}`}>
@@ -52,7 +53,7 @@ const AttachmentList: React.FC<Props> = ({ newFiles, errorFiles, removeFile }) =
                             {attachment.name}
                         </a>
 
-                        {editReport && (
+                        {editReport && showDocument && (
                             <Button
                                 iconId="ri-delete-bin-2-fill"
                                 title={t("delete_file", { fileName: attachment.name })}

--- a/src/features/reports/forms/DrawingForm.tsx
+++ b/src/features/reports/forms/DrawingForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "@/i18n";
 import { Feature } from "ol";
 import Layer from "ol/layer/Layer";
@@ -15,11 +15,13 @@ interface Props {
     clickedTool?: ClickedTool;
     handleToolClick?: (tool: ReportTool | undefined) => void;
     hideToolsDiv?: boolean;
+    onSubmitSketch?: () => void;
 }
 
-const DrawingForm: React.FC<Props> = ({ clickedTool, handleToolClick, hideToolsDiv }) => {
+const DrawingForm: React.FC<Props> = ({ clickedTool, handleToolClick, hideToolsDiv, onSubmitSketch }) => {
+    const [showSketch, setShowSketch] = useState<boolean>(false);
     const { map } = useMapStore();
-    const { selectedReport, selectedFeatures, setSelectedFeatures } = useReportStore();
+    const { selectedReport, selectedFeatures, setSelectedFeatures, editReport } = useReportStore();
 
     const importFileRef = useRef<HTMLInputElement>(null);
 
@@ -121,62 +123,77 @@ const DrawingForm: React.FC<Props> = ({ clickedTool, handleToolClick, hideToolsD
 
     return (
         <>
-            {!hideToolsDiv && (
-                <>
-                    <p className="fr-text--sm fr-mb-1v">{t("drawing_message")}</p>
-                    <div className="report-tools">
-                        <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("creation_tools")}</p>
-                        <div>
-                            {reportTools
-                                .filter((tool) => tool.type === "create")
-                                .map((tool) => (
-                                    <Button
-                                        key={tool.name}
-                                        id={`${tool.name}-report-drawer-${tool.type}`}
-                                        onClick={() => {
-                                            if (tool.name === toolNames.import) {
-                                                importFileRef?.current?.click();
-                                                return;
-                                            }
-                                            if (handleToolClick) handleToolClick(tool);
-                                        }}
-                                        priority={getToolPriority(tool)}
-                                        title={tool.title}
-                                        className="gpf-btn--tertiary drawing-tool"
-                                        disabled={isToolDisabled(tool)}
-                                    >
-                                        <></>
-                                    </Button>
-                                ))}
-                            <ImportSketchFile inputRef={importFileRef} />
-                        </div>
-                    </div>
+            <SketchList />
 
-                    <div className="report-tools">
-                        <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("edit_tools")}</p>
-                        <div>
-                            {reportTools
-                                .filter((tool) => tool.type === "edit")
-                                .map((tool) => (
-                                    <Button
-                                        key={tool.name}
-                                        id={`${tool.name}-report-drawer-${tool.type}`}
-                                        onClick={() => {
-                                            if (handleToolClick) handleToolClick(tool);
-                                        }}
-                                        priority={clickedTool?.name === tool.name && clickedTool.clicked ? "secondary" : "tertiary"}
-                                        title={tool.title}
-                                        className="gpf-btn--tertiary drawing-tool"
-                                    >
-                                        <></>
-                                    </Button>
-                                ))}
-                        </div>
-                    </div>
-                </>
+            {!hideToolsDiv && (
+                <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowSketch(!showSketch)}>
+                    {showSketch ? t("hide_sketchToEdit") : t("show_sketchToEdit")}
+                </Button>
             )}
 
-            <SketchList />
+            <>
+                {!hideToolsDiv && showSketch && (
+                    <>
+                        <>
+                            <p className="fr-text--sm fr-mb-1v">{t("drawing_message")}</p>
+                            <div className="report-tools">
+                                <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("creation_tools")}</p>
+                                <div>
+                                    {reportTools
+                                        .filter((tool) => tool.type === "create")
+                                        .map((tool) => (
+                                            <Button
+                                                key={tool.name}
+                                                id={`${tool.name}-report-drawer-${tool.type}`}
+                                                onClick={() => {
+                                                    if (tool.name === toolNames.import) {
+                                                        importFileRef?.current?.click();
+                                                        return;
+                                                    }
+                                                    if (handleToolClick) handleToolClick(tool);
+                                                }}
+                                                priority={getToolPriority(tool)}
+                                                title={tool.title}
+                                                className="gpf-btn--tertiary drawing-tool"
+                                                disabled={isToolDisabled(tool)}
+                                            >
+                                                <></>
+                                            </Button>
+                                        ))}
+                                    <ImportSketchFile inputRef={importFileRef} />
+                                </div>
+                            </div>
+
+                            <div className="report-tools">
+                                <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("edit_tools")}</p>
+                                <div>
+                                    {reportTools
+                                        .filter((tool) => tool.type === "edit")
+                                        .map((tool) => (
+                                            <Button
+                                                key={tool.name}
+                                                id={`${tool.name}-report-drawer-${tool.type}`}
+                                                onClick={() => {
+                                                    if (handleToolClick) handleToolClick(tool);
+                                                }}
+                                                priority={clickedTool?.name === tool.name && clickedTool.clicked ? "secondary" : "tertiary"}
+                                                title={tool.title}
+                                                className="gpf-btn--tertiary drawing-tool"
+                                            >
+                                                <></>
+                                            </Button>
+                                        ))}
+                                </div>
+                            </div>
+                        </>
+                        {editReport && (
+                            <Button className="fr-mt-4v fr-mb-4v" onClick={onSubmitSketch}>
+                                {t("save_sketch")}
+                            </Button>
+                        )}
+                    </>
+                )}
+            </>
         </>
     );
 };

--- a/src/features/reports/forms/DrawingForm.tsx
+++ b/src/features/reports/forms/DrawingForm.tsx
@@ -4,12 +4,13 @@ import { Feature } from "ol";
 import Layer from "ol/layer/Layer";
 import VectorSource, { VectorSourceEvent } from "ol/source/Vector";
 import useReportTools from "@/hooks/reports/useReportTools";
-import { useMapStore, useReportStore } from "@/store";
+import { useMapStore, useReportStore, useUserStore } from "@/store";
 import { ClickedTool, ReportTool, toolNames } from "@/constants/reports/types";
 import { getReportAllFeatures, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import Button from "@codegouvfr/react-dsfr/Button";
 import SketchList from "./SketchList";
 import ImportSketchFile from "./ImportSketchFile";
+import { STATUS_NOT_ALLOWED } from "@/constants/utils";
 
 interface Props {
     clickedTool?: ClickedTool;
@@ -28,6 +29,8 @@ const DrawingForm: React.FC<Props> = ({ clickedTool, handleToolClick, hideToolsD
     const { t } = useTranslation({ DrawingForm });
 
     const reportTools = useReportTools();
+
+    const { user } = useUserStore();
 
     const reportLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
     const reportSource = reportLayer?.getSource() as VectorSource;
@@ -121,79 +124,79 @@ const DrawingForm: React.FC<Props> = ({ clickedTool, handleToolClick, hideToolsD
         return false;
     };
 
+    const isOwner = Number(user?.id) === Number(selectedReport?.author?.id);
     return (
         <>
             <SketchList />
 
-            {!hideToolsDiv && (
-                <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowSketch(!showSketch)}>
-                    {showSketch ? t("hide_sketchToEdit") : t("show_sketchToEdit")}
+            {!hideToolsDiv && editReport && !showSketch && (
+                <Button className="fr-mt-4v" onClick={() => setShowSketch(!showSketch)}>
+                    {t("show_sketchToEdit")}
                 </Button>
             )}
 
-            <>
-                {!hideToolsDiv && showSketch && (
-                    <>
-                        <>
-                            <p className="fr-text--sm fr-mb-1v">{t("drawing_message")}</p>
-                            <div className="report-tools">
-                                <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("creation_tools")}</p>
-                                <div>
-                                    {reportTools
-                                        .filter((tool) => tool.type === "create")
-                                        .map((tool) => (
-                                            <Button
-                                                key={tool.name}
-                                                id={`${tool.name}-report-drawer-${tool.type}`}
-                                                onClick={() => {
-                                                    if (tool.name === toolNames.import) {
-                                                        importFileRef?.current?.click();
-                                                        return;
-                                                    }
-                                                    if (handleToolClick) handleToolClick(tool);
-                                                }}
-                                                priority={getToolPriority(tool)}
-                                                title={tool.title}
-                                                className="gpf-btn--tertiary drawing-tool"
-                                                disabled={isToolDisabled(tool)}
-                                            >
-                                                <></>
-                                            </Button>
-                                        ))}
-                                    <ImportSketchFile inputRef={importFileRef} />
-                                </div>
-                            </div>
+            {((!hideToolsDiv && showSketch) || (!editReport && !STATUS_NOT_ALLOWED.includes(selectedReport?.status ?? "") && isOwner)) && (
+                <>
+                    <p className="fr-text--sm fr-mb-1v">{t("drawing_message")}</p>
+                    <div className="report-tools">
+                        <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("creation_tools")}</p>
+                        <div>
+                            {reportTools
+                                .filter((tool) => tool.type === "create")
+                                .map((tool) => (
+                                    <Button
+                                        key={tool.name}
+                                        id={`${tool.name}-report-drawer-${tool.type}`}
+                                        onClick={() => {
+                                            if (tool.name === toolNames.import) {
+                                                importFileRef?.current?.click();
+                                                return;
+                                            }
+                                            if (handleToolClick) handleToolClick(tool);
+                                        }}
+                                        priority={getToolPriority(tool)}
+                                        title={tool.title}
+                                        className="gpf-btn--tertiary drawing-tool"
+                                        disabled={isToolDisabled(tool)}
+                                    >
+                                        <></>
+                                    </Button>
+                                ))}
+                            <ImportSketchFile inputRef={importFileRef} />
+                        </div>
+                    </div>
 
-                            <div className="report-tools">
-                                <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("edit_tools")}</p>
-                                <div>
-                                    {reportTools
-                                        .filter((tool) => tool.type === "edit")
-                                        .map((tool) => (
-                                            <Button
-                                                key={tool.name}
-                                                id={`${tool.name}-report-drawer-${tool.type}`}
-                                                onClick={() => {
-                                                    if (handleToolClick) handleToolClick(tool);
-                                                }}
-                                                priority={clickedTool?.name === tool.name && clickedTool.clicked ? "secondary" : "tertiary"}
-                                                title={tool.title}
-                                                className="gpf-btn--tertiary drawing-tool"
-                                            >
-                                                <></>
-                                            </Button>
-                                        ))}
-                                </div>
-                            </div>
-                        </>
-                        {editReport && (
-                            <Button className="fr-mt-4v fr-mb-4v" onClick={onSubmitSketch}>
-                                {t("save_sketch")}
-                            </Button>
-                        )}
-                    </>
-                )}
-            </>
+                    <div className="report-tools">
+                        <p className="fr-mt-4v fr-mb-2v fr-text--sm">{t("edit_tools")}</p>
+                        <div>
+                            {reportTools
+                                .filter((tool) => tool.type === "edit")
+                                .map((tool) => (
+                                    <Button
+                                        key={tool.name}
+                                        id={`${tool.name}-report-drawer-${tool.type}`}
+                                        onClick={() => {
+                                            if (handleToolClick) handleToolClick(tool);
+                                        }}
+                                        priority={clickedTool?.name === tool.name && clickedTool.clicked ? "secondary" : "tertiary"}
+                                        title={tool.title}
+                                        className="gpf-btn--tertiary drawing-tool"
+                                    >
+                                        <></>
+                                    </Button>
+                                ))}
+                        </div>
+                    </div>
+                </>
+            )}
+            {showSketch && (
+                <div className="report__actions">
+                    {editReport && <Button onClick={onSubmitSketch}>{t("save_sketch")}</Button>}
+                    <Button priority="secondary" onClick={() => setShowSketch(!showSketch)}>
+                        {t("hide_sketchToEdit")}
+                    </Button>
+                </div>
+            )}
         </>
     );
 };

--- a/src/features/reports/forms/OpenReplyReportModal.tsx
+++ b/src/features/reports/forms/OpenReplyReportModal.tsx
@@ -36,7 +36,7 @@ const OpenReplyReportModal: React.FC<Props> = ({ onClose }) => {
     }, [tableData, isChecked]);
 
     const CheckedIdStatus = React.useMemo(() => {
-        return tableData.filter((res) => !!isChecked[String(res.id)]).map((checkedStatus) => checkedStatus.exportData.statusText);
+        return tableData.filter((res) => !!isChecked[String(res.id)]).map((checkedStatus) => checkedStatus.exportData.status);
     }, [tableData, isChecked]);
 
     type MutationParams = {
@@ -105,7 +105,7 @@ const OpenReplyReportModal: React.FC<Props> = ({ onClose }) => {
                         const statusKey = key as StatusKey;
                         return (
                             <option key={statusKey} value={key}>
-                                {CheckedIdStatus}
+                                {reportImgStatus[statusKey].text}
                             </option>
                         );
                     })}

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -53,6 +53,8 @@ const ReportForm: React.FC<Props> = ({
     const [openSuivi, setOpenSuivi] = useState(false);
     const [committedStatus, setCommittedStatus] = useState("");
     const [showTheme, setShowTheme] = useState<boolean>(false);
+    const [showDescription, setShowDescription] = useState<boolean>(false);
+    const [showDocument, setShowDocument] = useState<boolean>(false);
 
     const accordionRef = useRef<HTMLDivElement>(null);
 
@@ -356,7 +358,7 @@ const ReportForm: React.FC<Props> = ({
                 <div className="fr-mt-12v">
                     <Accordion label={t("select_theme")} defaultExpanded={false}>
                         <>
-                            <p>{selectedReport?.themes.map((theme) => theme.theme).join(", ")}</p>
+                            <h3 className="fr-text--md">{selectedReport?.themes.map((theme) => theme.theme).join(", ")}</h3>
                             <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowTheme(!showTheme)}>
                                 {showTheme ? t("hide_themeToEdit") : t("show_themeToEdit")}
                             </Button>
@@ -394,21 +396,30 @@ const ReportForm: React.FC<Props> = ({
                         }}
                         expanded={expendedDescription}
                     >
-                        <Input
-                            label={t("describe_report_label")}
-                            textArea
-                            nativeTextAreaProps={{
-                                value: description,
-                                rows: 5,
-                                onChange: (e) => {
-                                    setDescription(e.target.value);
-                                },
-                            }}
-                        />
-                        {editReport && (
-                            <Button size="large" onClick={onSubmitDescription}>
-                                {t("submit_description")}
-                            </Button>
+                        {description ? <h3 className="fr-text--md">{description}</h3> : <p> {t("no_description")} </p>}
+                        <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowDescription(!showDescription)}>
+                            {showDescription ? t("hide_themeToEdit") : t("show_themeToEdit")}
+                        </Button>
+
+                        {showDescription && (
+                            <>
+                                <Input
+                                    label={t("describe_report_label")}
+                                    textArea
+                                    nativeTextAreaProps={{
+                                        value: description,
+                                        rows: 5,
+                                        onChange: (e) => {
+                                            setDescription(e.target.value);
+                                        },
+                                    }}
+                                />
+                                {editReport && (
+                                    <Button size="large" onClick={onSubmitDescription}>
+                                        {t("submit_description")}
+                                    </Button>
+                                )}
+                            </>
                         )}
                     </Accordion>
 
@@ -419,30 +430,39 @@ const ReportForm: React.FC<Props> = ({
                         }}
                         expanded={expendedDocument}
                     >
-                        <div
-                            style={{
-                                width: "100%",
-                            }}
-                        >
-                            <Upload
-                                ref={filesRef}
-                                label={t("import_attachments_label")}
-                                hint={t("import_attachments_hint", { maxSizeMB })}
-                                state={errorFiles.length ? "error" : filesUploaded.length ? "success" : "default"}
-                                stateRelatedMessage=""
-                                multiple
-                                className="upload-file"
-                                nativeInputProps={{
-                                    value: "",
-                                    accept: ".jpg,.png,.pdf",
-                                    onChange: (e) => onUploadChange(e),
-                                }}
-                            />
-                            <AttachmentList newFiles={filesUploaded} errorFiles={errorFiles} removeFile={removeFile} />
-                            {editReport && (
-                                <Button size="large" onClick={onSubmitDocument}>
-                                    {t("submit_document")}
-                                </Button>
+                        <div>
+                            {filesUploaded ? (
+                                <AttachmentList newFiles={filesUploaded} errorFiles={errorFiles} removeFile={removeFile} />
+                            ) : (
+                                <p> {t("no_document")} </p>
+                            )}
+
+                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowDocument(!showDocument)}>
+                                {showDocument ? t("hide_themeToEdit") : t("show_themeToEdit")}
+                            </Button>
+
+                            {showDocument && (
+                                <>
+                                    <Upload
+                                        ref={filesRef}
+                                        label={t("import_attachments_label")}
+                                        hint={t("import_attachments_hint", { maxSizeMB })}
+                                        state={errorFiles.length ? "error" : filesUploaded.length ? "success" : "default"}
+                                        stateRelatedMessage=""
+                                        multiple
+                                        className="upload-file"
+                                        nativeInputProps={{
+                                            value: "",
+                                            accept: ".jpg,.png,.pdf",
+                                            onChange: (e) => onUploadChange(e),
+                                        }}
+                                    />
+                                    {editReport && (
+                                        <Button className="fr-mt-4v" size="large" onClick={onSubmitDocument}>
+                                            {t("submit_document")}
+                                        </Button>
+                                    )}
+                                </>
                             )}
                         </div>
                     </Accordion>

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -23,7 +23,7 @@ import ThemeComponent from "./ThemeComponent";
 import DeleteShareReportComponent from "../DeleteShareReportComponent";
 import { useGetUserProfileAPI } from "@/api/userData";
 
-const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
+const allowedTypes = ["image/png", "image/jpg", "image/jpeg", "application/pdf"];
 const maxSizeMB = 3;
 const maxSizeBytes = maxSizeMB * 1024 * 1024;
 
@@ -62,7 +62,7 @@ const ReportForm: React.FC<Props> = ({
 
     const accordionRef = useRef<HTMLDivElement>(null);
 
-    const [expendedTheme, setExpendedTheme] = useState<boolean>(false);
+    const [expendedTheme, setExpendedTheme] = useState<boolean>(true);
     const [expendedDrawing, setExpendedDrawing] = useState<boolean>(false);
     const [expendedDescription, setExpendedDescription] = useState<boolean>(false);
     const [expendedDocument, setExpendedDocument] = useState<boolean>(false);
@@ -78,8 +78,17 @@ const ReportForm: React.FC<Props> = ({
     const { community } = useCommunityStore();
     const { data: userData } = useGetUserProfileAPI();
 
-    const { setSelectedReport, reports, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened, setDrawerOpened } =
-        useReportStore();
+    const {
+        setSelectedReport,
+        reports,
+        editReport,
+        selectedReport,
+        selectedFeatures,
+        setSelectedFeatures,
+        setTableDrawerOpened,
+        setDrawerOpened,
+        toggleSortByDateCreation,
+    } = useReportStore();
 
     const reportTools = useReportTools();
     const { confirmCancelModal } = useModalStore();
@@ -196,6 +205,7 @@ const ReportForm: React.FC<Props> = ({
     }, [editReport, themeAttributes, validateThemeAttributes]);
 
     const onSubmit = async () => {
+        toggleSortByDateCreation("DESC");
         if (clickedTool.clicked) handleToolClick(reportTools.find((tool) => tool.name === clickedTool.name));
 
         if (!validateTheme() || !validateFiles(filesUploaded)) {
@@ -386,7 +396,7 @@ const ReportForm: React.FC<Props> = ({
                     <h2 className="ri-map-pin-add-line fr-mt-4v fr-mb-1v fr-text--md">
                         {selectedReport ? t("edit_report_title", { reportId: selectedReport.id }) : t("create_report_title")}
                     </h2>
-                    {isAdmin && <DeleteShareReportComponent handleDelete={onDelete} />}
+                    {editReport && isAdmin && <DeleteShareReportComponent handleDelete={onDelete} />}
                 </div>
                 {selectedReport && <ReportFiltersComponent reportStatus={committedStatus} />}
                 {!selectedReport && (
@@ -395,16 +405,18 @@ const ReportForm: React.FC<Props> = ({
                     </p>
                 )}
 
-                <Button
-                    onClick={() => {
-                        setOpenSuivi(true);
-                        setTimeout(() => {
-                            accordionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-                        }, 100);
-                    }}
-                >
-                    {t("report_reply")}
-                </Button>
+                {editReport && (
+                    <Button
+                        onClick={() => {
+                            setOpenSuivi(true);
+                            setTimeout(() => {
+                                accordionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                            }, 100);
+                        }}
+                    >
+                        {t("report_reply")}
+                    </Button>
+                )}
                 <div className="fr-mt-12v">
                     <Accordion
                         label={t("select_theme")}
@@ -414,13 +426,14 @@ const ReportForm: React.FC<Props> = ({
                         expanded={expendedTheme}
                     >
                         <>
-                            <h3 className="fr-text--md">{selectedReport?.themes.map((theme) => theme.theme).join(", ")}</h3>
-                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => onToggleTheme()}>
-                                {showTheme ? t("hide_themeToEdit") : t("show_themeToEdit")}
-                            </Button>
+                            <h3 className="fr-text--md fr-mb-1v">{selectedReport?.themes.map((theme) => theme.theme).join(", ")}</h3>
+                            {editReport && !showTheme && (
+                                <Button className="fr-mt-4v" onClick={() => onToggleTheme()}>
+                                    {t("show_toEdit")}
+                                </Button>
+                            )}
                         </>
-
-                        {showTheme && (
+                        {(showTheme || !editReport) && (
                             <ThemeComponent
                                 communityThemes={community.themes}
                                 selectedTheme={selectedTheme}
@@ -432,6 +445,14 @@ const ReportForm: React.FC<Props> = ({
                                 onSubmitTheme={onSubmitTheme}
                                 themeRef={themeRef}
                             />
+                        )}
+                        {showTheme && (
+                            <div className="report__actions">
+                                {editReport && <Button onClick={onSubmitTheme}>{t("save_report")}</Button>}
+                                <Button priority="secondary" onClick={() => onToggleTheme()}>
+                                    {showTheme ? t("hide_toEdit") : editReport ? t("show_toEdit") : t("show_toCreate")}
+                                </Button>
+                            </div>
                         )}
                     </Accordion>
 
@@ -452,30 +473,33 @@ const ReportForm: React.FC<Props> = ({
                         }}
                         expanded={expendedDescription}
                     >
-                        {description ? <h3 className="fr-text--md">{description}</h3> : <p> {t("no_description")} </p>}
-                        <Button className="fr-mt-4v fr-mb-4v" onClick={() => onToggleDescription()}>
-                            {showDescription ? t("hide_themeToEdit") : t("show_themeToEdit")}
-                        </Button>
+                        {description && editReport ? <h3 className="fr-text--md fr-mb-1v">{description}</h3> : <p> {t("no_description")} </p>}
+                        {editReport && !showDescription && (
+                            <Button className="fr-mt-4v" onClick={() => onToggleDescription()}>
+                                {showDescription ? t("hide_toEdit") : editReport ? t("show_toEdit") : t("show_toCreate")}
+                            </Button>
+                        )}
 
+                        {(showDescription || !editReport) && (
+                            <Input
+                                label={t("describe_report_label")}
+                                textArea
+                                nativeTextAreaProps={{
+                                    value: description,
+                                    rows: 5,
+                                    onChange: (e) => {
+                                        setDescription(e.target.value);
+                                    },
+                                }}
+                            />
+                        )}
                         {showDescription && (
-                            <>
-                                <Input
-                                    label={t("describe_report_label")}
-                                    textArea
-                                    nativeTextAreaProps={{
-                                        value: description,
-                                        rows: 5,
-                                        onChange: (e) => {
-                                            setDescription(e.target.value);
-                                        },
-                                    }}
-                                />
-                                {editReport && (
-                                    <Button size="large" onClick={onSubmitDescription}>
-                                        {t("submit_description")}
-                                    </Button>
-                                )}
-                            </>
+                            <div className="report__actions">
+                                {editReport && <Button onClick={onSubmitDescription}>{t("submit_report")}</Button>}
+                                <Button priority="secondary" onClick={() => onToggleDescription()}>
+                                    {showDescription ? t("hide_toEdit") : editReport ? t("show_toEdit") : t("show_toCreate")}
+                                </Button>
+                            </div>
                         )}
                     </Accordion>
 
@@ -487,37 +511,41 @@ const ReportForm: React.FC<Props> = ({
                         expanded={expendedDocument}
                     >
                         <div>
-                            {filesUploaded ? (
-                                <AttachmentList newFiles={filesUploaded} errorFiles={errorFiles} removeFile={removeFile} />
-                            ) : (
-                                <p> {t("no_document")} </p>
+                            <AttachmentList newFiles={filesUploaded} errorFiles={errorFiles} removeFile={removeFile} showDocument={showDocument} />
+
+                            {editReport && !showDocument && (
+                                <Button className="fr-mt-4v" onClick={() => onToggleDocument()}>
+                                    {showDocument
+                                        ? t("hide_toEdit")
+                                        : editReport && selectedReport && selectedReport.attachments.length > 0
+                                          ? t("show_toEdit")
+                                          : t("show_toCreate")}
+                                </Button>
                             )}
-
-                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => onToggleDocument()}>
-                                {showDocument ? t("hide_themeToEdit") : t("show_themeToEdit")}
-                            </Button>
-
+                            {(showDocument || !editReport) && (
+                                <Upload
+                                    ref={filesRef}
+                                    label={t("import_attachments_label")}
+                                    hint={t("import_attachments_hint", { maxSizeMB })}
+                                    state={errorFiles.length ? "error" : filesUploaded.length ? "success" : "default"}
+                                    stateRelatedMessage=""
+                                    multiple
+                                    className="upload-file"
+                                    nativeInputProps={{
+                                        value: "",
+                                        accept: ".jpg,.png,.pdf",
+                                        onChange: (e) => onUploadChange(e),
+                                    }}
+                                />
+                            )}
                             {showDocument && (
                                 <>
-                                    <Upload
-                                        ref={filesRef}
-                                        label={t("import_attachments_label")}
-                                        hint={t("import_attachments_hint", { maxSizeMB })}
-                                        state={errorFiles.length ? "error" : filesUploaded.length ? "success" : "default"}
-                                        stateRelatedMessage=""
-                                        multiple
-                                        className="upload-file"
-                                        nativeInputProps={{
-                                            value: "",
-                                            accept: ".jpg,.png,.pdf",
-                                            onChange: (e) => onUploadChange(e),
-                                        }}
-                                    />
-                                    {editReport && (
-                                        <Button className="fr-mt-4v" size="large" onClick={onSubmitDocument}>
-                                            {t("submit_document")}
+                                    <div className="report__actions">
+                                        {editReport && <Button onClick={onSubmitDocument}>{t("submit_report")}</Button>}
+                                        <Button priority="secondary" onClick={() => onToggleDocument()}>
+                                            {showDocument ? t("hide_toEdit") : editReport ? t("show_toEdit") : t("show_toCreate")}
                                         </Button>
-                                    )}
+                                    </div>
                                 </>
                             )}
                         </div>
@@ -541,9 +569,7 @@ const ReportForm: React.FC<Props> = ({
 
                     {!selectedReport && (
                         <div className="submit">
-                            <Button size="large" onClick={onSubmit}>
-                                {t("submit_report")}
-                            </Button>
+                            <Button onClick={onSubmit}>{t("submit_report")}</Button>
                             <Button nativeButtonProps={confirmCancelModal.buttonProps} priority="tertiary" title="Annuler">
                                 {t("cancel_report")}
                             </Button>

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -397,13 +397,7 @@ const ReportForm: React.FC<Props> = ({
                         }}
                         expanded={expendedDrawing}
                     >
-                        <DrawingForm clickedTool={clickedTool} handleToolClick={handleToolClick} />
-
-                        {editReport && (
-                            <Button size="large" onClick={onSubmitSketch}>
-                                {t("submit_sketch")}
-                            </Button>
-                        )}
+                        <DrawingForm clickedTool={clickedTool} handleToolClick={handleToolClick} onSubmitSketch={onSubmitSketch} />
                     </Accordion>
 
                     <Accordion

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -12,15 +12,14 @@ import useReportTools from "@/hooks/reports/useReportTools";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
-import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { Upload } from "@codegouvfr/react-dsfr/Upload";
 import LoaderComponent from "@/components/LoaderComponent";
 import ReportFiltersComponent from "@/components/ReportFiltersComponent";
-import ThemeForm from "./ThemeForm";
 import DrawingForm from "./DrawingForm";
 import ConfirmCancelModal from "./ConfirmCancelModal";
 import AttachmentList from "./AttachmentList";
 import ReportTracking from "../ReportTracking";
+import ThemeComponent from "./ThemeComponent";
 
 const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
 const maxSizeMB = 3;
@@ -53,6 +52,7 @@ const ReportForm: React.FC<Props> = ({
 
     const [openSuivi, setOpenSuivi] = useState(false);
     const [committedStatus, setCommittedStatus] = useState("");
+    const [showTheme, setShowTheme] = useState<boolean>(false);
 
     const accordionRef = useRef<HTMLDivElement>(null);
 
@@ -355,38 +355,25 @@ const ReportForm: React.FC<Props> = ({
                 </Button>
                 <div className="fr-mt-12v">
                     <Accordion label={t("select_theme")} defaultExpanded={false}>
-                        <RadioButtons
-                            ref={themeRef}
-                            legend={t("select_theme")}
-                            options={community.themes.map((theme) => {
-                                return {
-                                    label: theme.theme,
-                                    nativeInputProps: {
-                                        checked: selectedTheme?.theme === theme.theme,
-                                        onClick: () => {
-                                            setSelectedTheme(theme);
-                                            setThemeAttributes(getThemeAttributes(theme));
-
-                                            setErrorTheme(() => "");
-                                        },
-                                        required: true,
-                                    },
-                                };
-                            })}
-                            state={errorTheme ? "error" : selectedTheme ? "success" : "default"}
-                            stateRelatedMessage={errorTheme ?? ""}
-                            orientation="horizontal"
-                            small
-                            className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
-                        />
-                        {selectedTheme && (
-                            <ThemeForm theme={selectedTheme} themeAttributes={themeAttributes} onChangeThemeAttributes={onChangeThemeAttributes} />
-                        )}
-
-                        {editReport && (
-                            <Button size="large" onClick={onSubmitTheme}>
-                                {t("submit_theme")}
+                        <>
+                            <p>{selectedReport?.themes.map((theme) => theme.theme).join(", ")}</p>
+                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowTheme(!showTheme)}>
+                                {showTheme ? t("hide_themeToEdit") : t("show_themeToEdit")}
                             </Button>
+                        </>
+
+                        {showTheme && (
+                            <ThemeComponent
+                                communityThemes={community.themes}
+                                selectedTheme={selectedTheme}
+                                setSelectedTheme={setSelectedTheme}
+                                themeAttributes={themeAttributes}
+                                onChangeThemeAttributes={onChangeThemeAttributes}
+                                errorTheme={errorTheme}
+                                editReport={editReport}
+                                onSubmitTheme={onSubmitTheme}
+                                themeRef={themeRef}
+                            />
                         )}
                     </Accordion>
 

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -69,7 +69,8 @@ const ReportForm: React.FC<Props> = ({
     const [loading, setLoading] = useState<boolean>(false);
 
     const { community } = useCommunityStore();
-    const { setSelectedReport, reports, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened } = useReportStore();
+    const { setSelectedReport, reports, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened, setDrawerOpened } =
+        useReportStore();
 
     const reportTools = useReportTools();
     const { confirmCancelModal } = useModalStore();
@@ -298,6 +299,7 @@ const ReportForm: React.FC<Props> = ({
         if (handleClose) handleClose();
 
         setTableDrawerOpened(true);
+        setDrawerOpened(false);
         setClickedControl(null);
     };
 

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -20,6 +20,8 @@ import ConfirmCancelModal from "./ConfirmCancelModal";
 import AttachmentList from "./AttachmentList";
 import ReportTracking from "../ReportTracking";
 import ThemeComponent from "./ThemeComponent";
+import DeleteShareReportComponent from "../DeleteShareReportComponent";
+import { useGetUserProfileAPI } from "@/api/userData";
 
 const allowedTypes = ["image/png", "image/jpg", "application/pdf"];
 const maxSizeMB = 3;
@@ -53,11 +55,14 @@ const ReportForm: React.FC<Props> = ({
     const [openSuivi, setOpenSuivi] = useState(false);
     const [committedStatus, setCommittedStatus] = useState("");
     const [showTheme, setShowTheme] = useState<boolean>(false);
+    const [themeInitial, setThemeInitial] = useState<CommunityTheme | null>(null);
     const [showDescription, setShowDescription] = useState<boolean>(false);
+    const [descriptionInitiale, setDescriptionInitiale] = useState<string>("");
     const [showDocument, setShowDocument] = useState<boolean>(false);
 
     const accordionRef = useRef<HTMLDivElement>(null);
 
+    const [expendedTheme, setExpendedTheme] = useState<boolean>(false);
     const [expendedDrawing, setExpendedDrawing] = useState<boolean>(false);
     const [expendedDescription, setExpendedDescription] = useState<boolean>(false);
     const [expendedDocument, setExpendedDocument] = useState<boolean>(false);
@@ -71,6 +76,8 @@ const ReportForm: React.FC<Props> = ({
     const [loading, setLoading] = useState<boolean>(false);
 
     const { community } = useCommunityStore();
+    const { data: userData } = useGetUserProfileAPI();
+
     const { setSelectedReport, reports, editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened, setDrawerOpened } =
         useReportStore();
 
@@ -291,6 +298,7 @@ const ReportForm: React.FC<Props> = ({
         setSelectedTheme(null);
         setDescription("");
         setFilesUploaded([]);
+        setExpendedTheme(false);
         setExpendedDescription(false);
         setExpendedDocument(false);
         setErrorTheme(() => "");
@@ -303,6 +311,39 @@ const ReportForm: React.FC<Props> = ({
         setTableDrawerOpened(true);
         setDrawerOpened(false);
         setClickedControl(null);
+    };
+
+    const onToggleTheme = () => {
+        if (!showTheme) {
+            setShowTheme(true);
+            setThemeInitial(selectedTheme);
+        } else {
+            setSelectedTheme(themeInitial);
+            setShowTheme(false);
+            setExpendedTheme(false);
+            setErrorTheme(() => "");
+        }
+    };
+    const onToggleDescription = () => {
+        if (!showDescription) {
+            setDescriptionInitiale(description);
+            setShowDescription(true);
+        } else {
+            setDescription(descriptionInitiale);
+            setShowDescription(false);
+            setExpendedDescription(false);
+        }
+    };
+
+    const onToggleDocument = () => {
+        if (!showDocument) {
+            setShowDocument(true);
+        } else {
+            setExpendedDocument(false);
+            setShowDocument(false);
+            setFilesUploaded([]);
+            setErrorFiles([]);
+        }
     };
 
     const removeFile = (file: File) => {
@@ -330,14 +371,23 @@ const ReportForm: React.FC<Props> = ({
         setThemeAttributes(attributes);
     };
 
+    const isAdmin = useMemo(() => {
+        const currentUser = userData?.communitiesMember?.filter((cm) => cm.communityId === community?.id);
+        return Array.isArray(currentUser) ? currentUser.some((role) => role.role === "admin") : false;
+    }, [userData, community?.id]);
+
     if (!community) return;
+
     return (
         <>
             <div className="report-drawer">
                 {loading && <LoaderComponent />}
-                <h2 className="ri-map-pin-add-line fr-mt-4v fr-mb-1v fr-text--md">
-                    {selectedReport ? t("edit_report_title", { reportId: selectedReport.id }) : t("create_report_title")}
-                </h2>
+                <div className="report-drawer__container">
+                    <h2 className="ri-map-pin-add-line fr-mt-4v fr-mb-1v fr-text--md">
+                        {selectedReport ? t("edit_report_title", { reportId: selectedReport.id }) : t("create_report_title")}
+                    </h2>
+                    {isAdmin && <DeleteShareReportComponent handleDelete={onDelete} />}
+                </div>
                 {selectedReport && <ReportFiltersComponent reportStatus={committedStatus} />}
                 {!selectedReport && (
                     <p className={`fr-text--sm fr-mb-1v ${selectedFeatures && !selectedFeatures.length ? "fr-message--error" : ""}`}>
@@ -356,10 +406,16 @@ const ReportForm: React.FC<Props> = ({
                     {t("report_reply")}
                 </Button>
                 <div className="fr-mt-12v">
-                    <Accordion label={t("select_theme")} defaultExpanded={false}>
+                    <Accordion
+                        label={t("select_theme")}
+                        onExpandedChange={() => {
+                            setExpendedTheme(!expendedTheme);
+                        }}
+                        expanded={expendedTheme}
+                    >
                         <>
                             <h3 className="fr-text--md">{selectedReport?.themes.map((theme) => theme.theme).join(", ")}</h3>
-                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowTheme(!showTheme)}>
+                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => onToggleTheme()}>
                                 {showTheme ? t("hide_themeToEdit") : t("show_themeToEdit")}
                             </Button>
                         </>
@@ -397,7 +453,7 @@ const ReportForm: React.FC<Props> = ({
                         expanded={expendedDescription}
                     >
                         {description ? <h3 className="fr-text--md">{description}</h3> : <p> {t("no_description")} </p>}
-                        <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowDescription(!showDescription)}>
+                        <Button className="fr-mt-4v fr-mb-4v" onClick={() => onToggleDescription()}>
                             {showDescription ? t("hide_themeToEdit") : t("show_themeToEdit")}
                         </Button>
 
@@ -437,7 +493,7 @@ const ReportForm: React.FC<Props> = ({
                                 <p> {t("no_document")} </p>
                             )}
 
-                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => setShowDocument(!showDocument)}>
+                            <Button className="fr-mt-4v fr-mb-4v" onClick={() => onToggleDocument()}>
                                 {showDocument ? t("hide_themeToEdit") : t("show_themeToEdit")}
                             </Button>
 
@@ -483,7 +539,7 @@ const ReportForm: React.FC<Props> = ({
 
                     {!selectedReport && t("report_note")}
 
-                    {!selectedReport ? (
+                    {!selectedReport && (
                         <div className="submit">
                             <Button size="large" onClick={onSubmit}>
                                 {t("submit_report")}
@@ -491,16 +547,6 @@ const ReportForm: React.FC<Props> = ({
                             <Button nativeButtonProps={confirmCancelModal.buttonProps} priority="tertiary" title="Annuler">
                                 {t("cancel_report")}
                             </Button>
-                        </div>
-                    ) : (
-                        <div className="buttons">
-                            <Button priority="secondary" onClick={onDelete}>
-                                {t("delete_report")}
-                            </Button>
-                            <Button priority="secondary" onClick={onClose}>
-                                {t("cancel_report")}
-                            </Button>
-                            <Button onClick={onSubmit}>{t("save_report")}</Button>
                         </div>
                     )}
                 </div>

--- a/src/features/reports/forms/SketchList.tsx
+++ b/src/features/reports/forms/SketchList.tsx
@@ -13,7 +13,7 @@ import { StatusMessage } from "@/constants/communities/types";
 import { SketchFeatureType, toolNames } from "@/constants/reports/types";
 import { REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import { selectionCircleStyle } from "@/constants/styles";
-import { getFeatureDiam, handleCenterToFeature, mainMarker, markersStyles, otherMarkers } from "@/constants/utils";
+import { getFeatureDiam, handleCenterToFeature, mainMarker, markersStyles, otherMarkers, STATUS_NOT_ALLOWED } from "@/constants/utils";
 import Button from "@codegouvfr/react-dsfr/Button";
 
 const hoveredFeatureStyle: { strockWidth: number; imageScale: number | Size } = { strockWidth: 1, imageScale: 1 };
@@ -21,7 +21,7 @@ const hoveredFeatureStyle: { strockWidth: number; imageScale: number | Size } = 
 const SketchList = () => {
     const { map } = useMapStore();
     const { addAlertMessage } = useCommunityStore();
-    const { selectedFeatures, setSelectedFeatures, editReport } = useReportStore();
+    const { selectedFeatures, setSelectedFeatures, editReport, selectedReport } = useReportStore();
 
     const clusterLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
     const clusterSource = clusterLayer?.getSource() as VectorSource;
@@ -122,7 +122,7 @@ const SketchList = () => {
 
     return (
         <div className="report-features">
-            {!sketchFeatures.length && <p>Aucun croquis associé</p>}
+            {!sketchFeatures.length && editReport && <p>Aucun croquis associé</p>}
             {sketchFeatures.map((feature, index) => {
                 const featureType = feature.getGeometry()?.getType();
                 const featureStyle = feature.getStyle() as Style;
@@ -156,7 +156,7 @@ const SketchList = () => {
                             <span>{text}</span>
                         </div>
 
-                        {editReport && (
+                        {editReport && selectedReport?.status && !STATUS_NOT_ALLOWED.includes(selectedReport.status) && (
                             <Button
                                 iconId="ri-delete-bin-2-fill"
                                 priority={"tertiary"}

--- a/src/features/reports/forms/ThemeComponent.tsx
+++ b/src/features/reports/forms/ThemeComponent.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { CommunityTheme } from "@/constants/communities/types";
+import ThemeForm from "./ThemeForm";
+import { PostThemeReport } from "@/constants/reports/types";
+import { useTranslation } from "@/i18n";
+
+interface Props {
+    communityThemes: CommunityTheme[];
+    selectedTheme: CommunityTheme | null;
+    setSelectedTheme: (theme: CommunityTheme) => void;
+    themeAttributes: PostThemeReport;
+    onChangeThemeAttributes: (attributes: PostThemeReport) => void;
+    errorTheme: string;
+    editReport?: boolean;
+    onSubmitTheme: () => Promise<void>;
+    themeRef: React.RefObject<HTMLFieldSetElement | null>;
+}
+
+const ThemeComponent: React.FC<Props> = ({
+    communityThemes,
+    selectedTheme,
+    setSelectedTheme,
+    themeAttributes,
+    onChangeThemeAttributes,
+    errorTheme,
+    editReport,
+    onSubmitTheme,
+    themeRef,
+}) => {
+    const { t } = useTranslation({ ThemeComponent });
+    return (
+        <>
+            <RadioButtons
+                ref={themeRef}
+                legend={t("select_theme")}
+                options={communityThemes.map((theme) => ({
+                    label: theme.theme,
+                    nativeInputProps: {
+                        checked: selectedTheme?.theme === theme.theme,
+                        onClick: () => {
+                            setSelectedTheme(theme);
+                            onChangeThemeAttributes({});
+                        },
+                        required: true,
+                    },
+                }))}
+                state={errorTheme ? "error" : selectedTheme ? "success" : "default"}
+                stateRelatedMessage={errorTheme ?? ""}
+                orientation="horizontal"
+                small
+                className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
+            />
+            {selectedTheme && <ThemeForm theme={selectedTheme} themeAttributes={themeAttributes} onChangeThemeAttributes={onChangeThemeAttributes} />}
+            {editReport && (
+                <Button size="large" onClick={onSubmitTheme}>
+                    {t("submit_theme")}
+                </Button>
+            )}
+        </>
+    );
+};
+
+export default ThemeComponent;

--- a/src/features/reports/forms/ThemeComponent.tsx
+++ b/src/features/reports/forms/ThemeComponent.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
-import Button from "@codegouvfr/react-dsfr/Button";
 import { CommunityTheme } from "@/constants/communities/types";
 import ThemeForm from "./ThemeForm";
 import { PostThemeReport } from "@/constants/reports/types";
@@ -25,8 +24,7 @@ const ThemeComponent: React.FC<Props> = ({
     themeAttributes,
     onChangeThemeAttributes,
     errorTheme,
-    editReport,
-    onSubmitTheme,
+
     themeRef,
 }) => {
     const { t } = useTranslation({ ThemeComponent });
@@ -53,11 +51,6 @@ const ThemeComponent: React.FC<Props> = ({
                 className="theme-radio fr-mt-4v fr-mb-1v fr-text--md"
             />
             {selectedTheme && <ThemeForm theme={selectedTheme} themeAttributes={themeAttributes} onChangeThemeAttributes={onChangeThemeAttributes} />}
-            {editReport && (
-                <Button size="large" onClick={onSubmitTheme}>
-                    {t("submit_theme")}
-                </Button>
-            )}
         </>
     );
 };

--- a/src/features/reports/forms/locale/ConfirmDeleteReportModal.locale.tsx
+++ b/src/features/reports/forms/locale/ConfirmDeleteReportModal.locale.tsx
@@ -5,9 +5,9 @@ export const ConfirmDeleteReportModalFrTranslations: Translations<"fr">["Confirm
     deleteReport_title: "Supprimer le signalement",
     deleteReports_title: "Supprimer les signalements",
     deleteReport_message:
-        "Êtes-vous sur·e de vouloir supprimer le  signalement sélectionné ? Cette action est irréversible et les signalements ne pourront être récupérés.",
+        "Êtes-vous sûr·e de vouloir supprimer le  signalement sélectionné ? Cette action est irréversible et les signalements ne pourront être récupérés.",
     deleteReports_message: ({ reportIdCount }: { reportIdCount: number | null }) =>
-        `Êtes-vous sur·e de vouloir supprimer les ${reportIdCount} signalements sélectionnés ? Cette action est irréversible et les signalements ne pourront être récupérés.`,
+        `Êtes-vous sûr·e de vouloir supprimer les ${reportIdCount} signalements sélectionnés ? Cette action est irréversible et les signalements ne pourront être récupérés.`,
     cancel_btn: "Annuler",
     delete_btn: "Supprimer",
 };

--- a/src/features/reports/forms/locale/DrawingForm.locale.tsx
+++ b/src/features/reports/forms/locale/DrawingForm.locale.tsx
@@ -6,7 +6,7 @@ export const DrawingFormFrTranslations: Translations<"fr">["DrawingForm"] = {
     creation_tools: "Outils de création",
     edit_tools: "Outils de modification",
     hide_sketchToEdit: "Annuler",
-    show_sketchToEdit: "Ajouter un croquis",
+    show_sketchToEdit: "Ajouter",
     save_sketch: "Enregitrer",
 };
 
@@ -15,7 +15,7 @@ export const DrawingFormEnTranslations: Translations<"en">["DrawingForm"] = {
     creation_tools: "Creation tools",
     edit_tools: "Editing tools",
     hide_sketchToEdit: "Cancel",
-    show_sketchToEdit: "Add sketch",
+    show_sketchToEdit: "Add",
     save_sketch: "Save",
 };
 

--- a/src/features/reports/forms/locale/DrawingForm.locale.tsx
+++ b/src/features/reports/forms/locale/DrawingForm.locale.tsx
@@ -5,13 +5,21 @@ export const DrawingFormFrTranslations: Translations<"fr">["DrawingForm"] = {
     drawing_message: "Vous pouvez ici réaliser/importer un croquis explicatif sur la carte:",
     creation_tools: "Outils de création",
     edit_tools: "Outils de modification",
+    hide_sketchToEdit: "Annuler",
+    show_sketchToEdit: "Ajouter un croquis",
+    save_sketch: "Enregitrer",
 };
 
 export const DrawingFormEnTranslations: Translations<"en">["DrawingForm"] = {
     drawing_message: "Here you can create/import an explanatory sketch on the map:",
     creation_tools: "Creation tools",
     edit_tools: "Editing tools",
+    hide_sketchToEdit: "Cancel",
+    show_sketchToEdit: "Add sketch",
+    save_sketch: "Save",
 };
 
-const { i18n } = declareComponentKeys<"drawing_message" | "creation_tools" | "edit_tools">()("DrawingForm");
+const { i18n } = declareComponentKeys<"drawing_message" | "creation_tools" | "edit_tools" | "hide_sketchToEdit" | "show_sketchToEdit" | "save_sketch">()(
+    "DrawingForm"
+);
 export type I18n = typeof i18n;

--- a/src/features/reports/forms/locale/ReportForm.locale.tsx
+++ b/src/features/reports/forms/locale/ReportForm.locale.tsx
@@ -24,13 +24,11 @@ export const ReportFormFrTranslations: Translations<"fr">["ReportForm"] = {
             </a>
         </div>
     ),
-    submit_report: "Envoyer le signalement",
-    submit_theme: "Enregistrer le thème",
-    hide_themeToEdit: "Annuler",
-    show_themeToEdit: "Modifier",
-    submit_sketch: "Enregistrer le croquis",
-    submit_description: "Enregistrer la description",
-    submit_document: "Enregistrer le document",
+    send_report: "Envoyer le signalement",
+    submit_report: "Enregistrer",
+    hide_toEdit: "Annuler",
+    show_toEdit: "Modifier",
+    show_toCreate: "Ajouter",
     cancel_report: "Annuler",
     delete_report: "Supprimer",
     save_report: "Enregistrer",
@@ -68,13 +66,11 @@ export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
             </a>
         </div>
     ),
-    submit_report: "Send the report",
-    submit_theme: "Save the theme",
-    hide_themeToEdit: "Cancel",
-    show_themeToEdit: "Edit",
-    submit_sketch: "Save the sketch",
-    submit_description: "Save the description",
-    submit_document: "Save the document",
+    send_report: "Send the report",
+    submit_report: "Save",
+    hide_toEdit: "Cancel",
+    show_toEdit: "Edit",
+    show_toCreate: "Add",
     cancel_report: "Cancel",
     delete_report: "Delete",
     save_report: "Save",
@@ -105,12 +101,10 @@ const { i18n } = declareComponentKeys<
     | { K: "import_attachments_hint"; P: { maxSizeMB: number }; R: string }
     | { K: "report_note"; R: JSX.Element }
     | "submit_report"
-    | "submit_theme"
-    | "hide_themeToEdit"
-    | "show_themeToEdit"
-    | "submit_description"
-    | "submit_document"
-    | "submit_sketch"
+    | "send_report"
+    | "hide_toEdit"
+    | "show_toEdit"
+    | "show_toCreate"
     | "cancel_report"
     | "delete_report"
     | "save_report"

--- a/src/features/reports/forms/locale/ReportForm.locale.tsx
+++ b/src/features/reports/forms/locale/ReportForm.locale.tsx
@@ -24,6 +24,8 @@ export const ReportFormFrTranslations: Translations<"fr">["ReportForm"] = {
     ),
     submit_report: "Envoyer le signalement",
     submit_theme: "Enregistrer le thème",
+    hide_themeToEdit: "Annuler",
+    show_themeToEdit: "Modifier",
     submit_sketch: "Enregistrer le croquis",
     submit_description: "Enregistrer la description",
     submit_document: "Enregistrer le document",
@@ -64,6 +66,8 @@ export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
     ),
     submit_report: "Send the report",
     submit_theme: "Save the theme",
+    hide_themeToEdit: "Cancel",
+    show_themeToEdit: "Edit",
     submit_sketch: "Save the sketch",
     submit_description: "Save the description",
     submit_document: "Save the document",
@@ -96,6 +100,8 @@ const { i18n } = declareComponentKeys<
     | { K: "report_note"; R: JSX.Element }
     | "submit_report"
     | "submit_theme"
+    | "hide_themeToEdit"
+    | "show_themeToEdit"
     | "submit_description"
     | "submit_document"
     | "submit_sketch"

--- a/src/features/reports/forms/locale/ReportForm.locale.tsx
+++ b/src/features/reports/forms/locale/ReportForm.locale.tsx
@@ -11,6 +11,8 @@ export const ReportFormFrTranslations: Translations<"fr">["ReportForm"] = {
     draw_sketch: "Dessiner un croquis",
     describe_report: "Décrire le signalement",
     describe_report_label: "Explicitez votre signalement de façon la plus détaillée possible :",
+    no_description: "Aucune description ajoutée",
+    no_document: "Aucun document ajouté",
     import_attachments: "Joindre des documents",
     import_attachments_label: "Aidez nous à comprendre votre signalement. Ajouter par exemple des photos ou autres documents pour préciser votre message.",
     import_attachments_hint: ({ maxSizeMB }: { maxSizeMB: number }) => `Taille maximale : ${maxSizeMB} Mo. Formats supportés : JPG, PNG, PDF`,
@@ -53,6 +55,8 @@ export const ReportFormEnTranslations: Translations<"en">["ReportForm"] = {
     draw_sketch: "Draw a sketch",
     describe_report: "Describe the report",
     describe_report_label: "Explain your report in as much detail as possible:",
+    no_description: "No description added",
+    no_document: "No document added",
     import_attachments: "Attach documents",
     import_attachments_label: "Help us understand your report. For example, add photos or other documents to clarify your message.",
     import_attachments_hint: ({ maxSizeMB }: { maxSizeMB: number }) => `Maximum size: ${maxSizeMB} MB. Supported formats: JPG, PNG, PDF`,
@@ -94,6 +98,8 @@ const { i18n } = declareComponentKeys<
     | "draw_sketch"
     | "describe_report"
     | "describe_report_label"
+    | "no_description"
+    | "no_document"
     | "import_attachments"
     | "import_attachments_label"
     | { K: "import_attachments_hint"; P: { maxSizeMB: number }; R: string }

--- a/src/features/reports/forms/locale/ThemeComponent.locale.tsx
+++ b/src/features/reports/forms/locale/ThemeComponent.locale.tsx
@@ -1,0 +1,17 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const ThemeComponentFrTranslations: Translations<"fr">["ThemeComponent"] = {
+    select_theme: "Choisir un thème *:",
+    draw_sketch: "Dessiner un croquis",
+    submit_theme: "Enregistrer le thème",
+};
+
+export const ThemeComponentEnTranslations: Translations<"en">["ThemeComponent"] = {
+    select_theme: "Choose a theme *:",
+    draw_sketch: "Draw a sketch",
+    submit_theme: "Save the theme",
+};
+
+const { i18n } = declareComponentKeys<"select_theme" | "draw_sketch" | "submit_theme">()("ThemeComponent");
+export type I18n = typeof i18n;

--- a/src/features/reports/locale/ConfirmDeleteShareReportModal.locale.tsx
+++ b/src/features/reports/locale/ConfirmDeleteShareReportModal.locale.tsx
@@ -1,0 +1,20 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const ConfirmDeleteShareReportModalFrTranslations: Translations<"fr">["ConfirmDeleteShareReportModal"] = {
+    deleteReports_title: "Supprimer le signalement",
+    cancel_btn: "Annuler",
+    delete_btn: "Supprimer",
+    deleteReport_message:
+        "Êtes-vous sur.e de vouloir supprimer le signalement sélectionné ? Cette action est irréversible et les signalements ne pourront être récupérés.",
+};
+
+export const ConfirmDeleteShareReportModalEnTranslations: Translations<"en">["ConfirmDeleteShareReportModal"] = {
+    deleteReports_title: "Delete the report",
+    cancel_btn: "Cancel",
+    delete_btn: "Delete",
+    deleteReport_message: "Are you sure you want to delete the selected report? This action is irreversible and the reports cannot be recovered.",
+};
+
+const { i18n } = declareComponentKeys<"deleteReports_title" | "cancel_btn" | "delete_btn" | "deleteReport_message">()("ConfirmDeleteShareReportModal");
+export type I18n = typeof i18n;

--- a/src/features/reports/locale/ConfirmDeleteShareReportModal.locale.tsx
+++ b/src/features/reports/locale/ConfirmDeleteShareReportModal.locale.tsx
@@ -6,7 +6,7 @@ export const ConfirmDeleteShareReportModalFrTranslations: Translations<"fr">["Co
     cancel_btn: "Annuler",
     delete_btn: "Supprimer",
     deleteReport_message:
-        "Êtes-vous sur.e de vouloir supprimer le signalement sélectionné ? Cette action est irréversible et les signalements ne pourront être récupérés.",
+        "Êtes-vous sûr·e de vouloir supprimer le signalement sélectionné ? Cette action est irréversible et les signalements ne pourront être récupérés.",
 };
 
 export const ConfirmDeleteShareReportModalEnTranslations: Translations<"en">["ConfirmDeleteShareReportModal"] = {

--- a/src/features/reports/locale/EditReport.locale.tsx
+++ b/src/features/reports/locale/EditReport.locale.tsx
@@ -2,6 +2,7 @@ import { Translations } from "@/i18n/types";
 import { declareComponentKeys } from "i18nifty";
 
 export const EditReportFrTranslations: Translations<"fr">["EditReport"] = {
+    report_back: "Tous les signalements",
     report_deleted_error: "Erreur dans la suppression du signalement !",
     report_deleted_success: ({ reportId }: { reportId: number }) => `Le signalement ${reportId} est supprimé avec succès.`,
     report_updated_error: "Erreur dans la mise à jour du signalement",
@@ -13,6 +14,7 @@ export const EditReportFrTranslations: Translations<"fr">["EditReport"] = {
 };
 
 export const EditReportEnTranslations: Translations<"en">["EditReport"] = {
+    report_back: "All reports",
     report_deleted_error: "Error deleting report!",
     report_deleted_success: ({ reportId }: { reportId: number }) => `Report ${reportId} is successfully deleted.`,
     report_updated_error: "Error in updating the report",
@@ -24,6 +26,7 @@ export const EditReportEnTranslations: Translations<"en">["EditReport"] = {
 };
 
 const { i18n } = declareComponentKeys<
+    | "report_back"
     | "report_deleted_error"
     | { K: "report_deleted_success"; P: { reportId: number }; R: string }
     | "report_updated_error"

--- a/src/features/reports/locale/ReportDrawer.locale.tsx
+++ b/src/features/reports/locale/ReportDrawer.locale.tsx
@@ -1,0 +1,13 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const ReportDrawerFrTranslations: Translations<"fr">["ReportDrawer"] = {
+    close: "Fermer",
+};
+
+export const ReportDrawerEnTranslations: Translations<"en">["ReportDrawer"] = {
+    close: "Close",
+};
+
+const { i18n } = declareComponentKeys<"close">()("ReportDrawer");
+export type I18n = typeof i18n;

--- a/src/features/reports/locale/ReportTracking.locale.tsx
+++ b/src/features/reports/locale/ReportTracking.locale.tsx
@@ -5,13 +5,15 @@ export const ReportTrackingFrTranslations: Translations<"fr">["ReportTracking"] 
     report_status: "Statut",
     report_content: "Votre message",
     report_send: "Envoyer",
+    no_reply: "Aucune réponse disponible",
 };
 
 export const ReportTrackingEnTranslations: Translations<"en">["ReportTracking"] = {
     report_status: "Status",
     report_content: "Your message",
     report_send: "Send",
+    no_reply: "No reply available",
 };
 
-const { i18n } = declareComponentKeys<"report_status" | "report_content" | "report_send">()("ReportTracking");
+const { i18n } = declareComponentKeys<"report_status" | "report_content" | "report_send" | "no_reply">()("ReportTracking");
 export type I18n = typeof i18n;

--- a/src/features/reports/table/CreateTableData.tsx
+++ b/src/features/reports/table/CreateTableData.tsx
@@ -31,7 +31,8 @@ const CreateTableData = (
                 opening_date: date,
                 departement,
                 theme: themes,
-                statusText,
+                status: statusText,
+                statusCode: report.status || "-",
             },
             row: [
                 <Checkbox

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -6,7 +6,7 @@ import VectorSource from "ol/source/Vector";
 import { getTableReports } from "@/api/reportsData";
 import { useReportStore, useModalStore, useMapStore, useLocalStorageStore } from "@/store";
 import { useCommunityStore } from "@/store/useCommunityStore";
-import { handleShowOnMap } from "@/constants/utils";
+import { handleShowOnMap, STATUS_NOT_ALLOWED } from "@/constants/utils";
 import { REPORT_TABLE_LIMIT_OPTIONS, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import GetReportsLayer from "@/features/navigation/layers/GetReportsLayer";
 import { StatusMessage } from "@/constants/communities/types";
@@ -50,6 +50,7 @@ const TableReport = () => {
         setCurrentPage,
         setSelectedReport,
         reportTableWidth,
+        toggleSortByDateCreation,
     } = useReportStore();
 
     const { replyReportModal, deleteReportModal } = useModalStore();
@@ -154,6 +155,8 @@ const TableReport = () => {
         return selectedLines.filter((res) => !!isChecked[String(res.id)]).map((res) => res.exportData);
     }, [selectedLines, isChecked]);
 
+    const allLinesAreAllowed = checkedLines.some((line) => STATUS_NOT_ALLOWED.includes(line.statusCode));
+
     const downloadedTable = useMemo(() => {
         if (checkedLines.length > 0) return checkedLines.map((exp) => exp);
         if (Array.isArray(selectedLines)) {
@@ -185,13 +188,7 @@ const TableReport = () => {
         });
     };
     const sortByDateCreation = () => {
-        setSortOrder((prev) => {
-            const newOrder = prev === "ASC" ? "DESC" : "ASC";
-            const sortParams = `opening_date:${newOrder}`;
-            setSortBy(sortParams);
-            setCurrentPage(1);
-            return newOrder;
-        });
+        toggleSortByDateCreation();
     };
 
     return (
@@ -220,7 +217,7 @@ const TableReport = () => {
                                 className="fr-btn fr-btn--secondary report-download__btn fr-icon-download-line fr-icon--sm"
                                 headers={tableHeader}
                                 data={downloadedTable}
-                                filename="export-filtre.csv"
+                                filename="export-reports.csv"
                             ></CSVLink>
                             <Button
                                 type="button"
@@ -234,7 +231,7 @@ const TableReport = () => {
                             <Button
                                 nativeButtonProps={replyReportModal.buttonProps}
                                 type="button"
-                                disabled={!isChecked || !Object.values(isChecked).some(Boolean)}
+                                disabled={!isChecked || !Object.values(isChecked).some(Boolean) || allLinesAreAllowed}
                             >
                                 {t("report_reply")}
                             </Button>

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -18,6 +18,7 @@ import { ThemeFormEnTranslations } from "@/features/reports/forms/locale/ThemeFo
 import { CenterMessageEnTranslations } from "@/features/reports/locale/CenterMessage.locale";
 import { CreateReportEnTranslations } from "@/features/reports/locale/CreateReport.locale";
 import { EditReportEnTranslations } from "@/features/reports/locale/EditReport.locale";
+import { ReportDrawerEnTranslations } from "@/features/reports/locale/ReportDrawer.locale";
 import { ShowReportEnTranslations } from "@/features/reports/locale/ShowReport.locale";
 import { ConfirmDeleteShareReportModalEnTranslations } from "@/features/reports/locale/ConfirmDeleteShareReportModal.locale";
 import { ReportTrackingEnTranslations } from "@/features/reports/locale/ReportTracking.locale";
@@ -64,6 +65,7 @@ export const translations: Translations<"en"> = {
     CenterMessage: CenterMessageEnTranslations,
     CreateReport: CreateReportEnTranslations,
     EditReport: EditReportEnTranslations,
+    ReportDrawer: ReportDrawerEnTranslations,
     ShowReport: ShowReportEnTranslations,
     ConfirmDeleteShareReportModal: ConfirmDeleteShareReportModalEnTranslations,
     ReportTracking: ReportTrackingEnTranslations,

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -13,6 +13,7 @@ import { ConfirmDeleteReportModalEnTranslations } from "@/features/reports/forms
 import { DrawingFormEnTranslations } from "@/features/reports/forms/locale/DrawingForm.locale";
 import { ImportSketchFileEnTranslations } from "@/features/reports/forms/locale/ImportSketchFile.locale";
 import { ReportFormEnTranslations } from "@/features/reports/forms/locale/ReportForm.locale";
+import { ThemeComponentEnTranslations } from "@/features/reports/forms/locale/ThemeComponent.locale";
 import { ThemeFormEnTranslations } from "@/features/reports/forms/locale/ThemeForm.locale";
 import { CenterMessageEnTranslations } from "@/features/reports/locale/CenterMessage.locale";
 import { CreateReportEnTranslations } from "@/features/reports/locale/CreateReport.locale";
@@ -57,6 +58,7 @@ export const translations: Translations<"en"> = {
     DrawingForm: DrawingFormEnTranslations,
     ImportSketchFile: ImportSketchFileEnTranslations,
     ReportForm: ReportFormEnTranslations,
+    ThemeComponent: ThemeComponentEnTranslations,
     ThemeForm: ThemeFormEnTranslations,
     CenterMessage: CenterMessageEnTranslations,
     CreateReport: CreateReportEnTranslations,

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -19,6 +19,7 @@ import { CenterMessageEnTranslations } from "@/features/reports/locale/CenterMes
 import { CreateReportEnTranslations } from "@/features/reports/locale/CreateReport.locale";
 import { EditReportEnTranslations } from "@/features/reports/locale/EditReport.locale";
 import { ShowReportEnTranslations } from "@/features/reports/locale/ShowReport.locale";
+import { ConfirmDeleteShareReportModalEnTranslations } from "@/features/reports/locale/ConfirmDeleteShareReportModal.locale";
 import { ReportTrackingEnTranslations } from "@/features/reports/locale/ReportTracking.locale";
 import { useGetReportsLayerEnTranslations } from "@/hooks/navigation/layers/locale/useGetReportsLayer.locale";
 import { useGetWFSLayerEnTranslations } from "@/hooks/navigation/layers/locale/useGetWFSLayer.locale";
@@ -64,6 +65,7 @@ export const translations: Translations<"en"> = {
     CreateReport: CreateReportEnTranslations,
     EditReport: EditReportEnTranslations,
     ShowReport: ShowReportEnTranslations,
+    ConfirmDeleteShareReportModal: ConfirmDeleteShareReportModalEnTranslations,
     ReportTracking: ReportTrackingEnTranslations,
     useGetReportsLayer: useGetReportsLayerEnTranslations,
     useGetWFSLayer: useGetWFSLayerEnTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -18,6 +18,7 @@ import { ThemeFormFrTranslations } from "@/features/reports/forms/locale/ThemeFo
 import { CenterMessageFrTranslations } from "@/features/reports/locale/CenterMessage.locale";
 import { CreateReportFrTranslations } from "@/features/reports/locale/CreateReport.locale";
 import { EditReportFrTranslations } from "@/features/reports/locale/EditReport.locale";
+import { ReportDrawerFrTranslations } from "@/features/reports/locale/ReportDrawer.locale";
 import { ShowReportFrTranslations } from "@/features/reports/locale/ShowReport.locale";
 import { ConfirmDeleteShareReportModalFrTranslations } from "@/features/reports/locale/ConfirmDeleteShareReportModal.locale";
 import { ReportTrackingFrTranslations } from "@/features/reports/locale/ReportTracking.locale";
@@ -64,6 +65,7 @@ export const translations: Translations<"fr"> = {
     CenterMessage: CenterMessageFrTranslations,
     CreateReport: CreateReportFrTranslations,
     EditReport: EditReportFrTranslations,
+    ReportDrawer: ReportDrawerFrTranslations,
     ShowReport: ShowReportFrTranslations,
     ConfirmDeleteShareReportModal: ConfirmDeleteShareReportModalFrTranslations,
     ReportTracking: ReportTrackingFrTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -19,6 +19,7 @@ import { CenterMessageFrTranslations } from "@/features/reports/locale/CenterMes
 import { CreateReportFrTranslations } from "@/features/reports/locale/CreateReport.locale";
 import { EditReportFrTranslations } from "@/features/reports/locale/EditReport.locale";
 import { ShowReportFrTranslations } from "@/features/reports/locale/ShowReport.locale";
+import { ConfirmDeleteShareReportModalFrTranslations } from "@/features/reports/locale/ConfirmDeleteShareReportModal.locale";
 import { ReportTrackingFrTranslations } from "@/features/reports/locale/ReportTracking.locale";
 import { useGetReportsLayerFrTranslations } from "@/hooks/navigation/layers/locale/useGetReportsLayer.locale";
 import { useGetWFSLayerFrTranslations } from "@/hooks/navigation/layers/locale/useGetWFSLayer.locale";
@@ -64,6 +65,7 @@ export const translations: Translations<"fr"> = {
     CreateReport: CreateReportFrTranslations,
     EditReport: EditReportFrTranslations,
     ShowReport: ShowReportFrTranslations,
+    ConfirmDeleteShareReportModal: ConfirmDeleteShareReportModalFrTranslations,
     ReportTracking: ReportTrackingFrTranslations,
     useGetReportsLayer: useGetReportsLayerFrTranslations,
     useGetWFSLayer: useGetWFSLayerFrTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -13,6 +13,7 @@ import { ConfirmDeleteReportModalFrTranslations } from "@/features/reports/forms
 import { DrawingFormFrTranslations } from "@/features/reports/forms/locale/DrawingForm.locale";
 import { ImportSketchFileFrTranslations } from "@/features/reports/forms/locale/ImportSketchFile.locale";
 import { ReportFormFrTranslations } from "@/features/reports/forms/locale/ReportForm.locale";
+import { ThemeComponentFrTranslations } from "@/features/reports/forms/locale/ThemeComponent.locale";
 import { ThemeFormFrTranslations } from "@/features/reports/forms/locale/ThemeForm.locale";
 import { CenterMessageFrTranslations } from "@/features/reports/locale/CenterMessage.locale";
 import { CreateReportFrTranslations } from "@/features/reports/locale/CreateReport.locale";
@@ -57,6 +58,7 @@ export const translations: Translations<"fr"> = {
     DrawingForm: DrawingFormFrTranslations,
     ImportSketchFile: ImportSketchFileFrTranslations,
     ReportForm: ReportFormFrTranslations,
+    ThemeComponent: ThemeComponentFrTranslations,
     ThemeForm: ThemeFormFrTranslations,
     CenterMessage: CenterMessageFrTranslations,
     CreateReport: CreateReportFrTranslations,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -39,6 +39,7 @@ export type ComponentKey =
     | import("../features/reports/forms/locale/DrawingForm.locale").I18n
     | import("../features/reports/forms/locale/ImportSketchFile.locale").I18n
     | import("../features/reports/forms/locale/ReportForm.locale").I18n
+    | import("../features/reports/forms/locale/ThemeComponent.locale").I18n
     | import("../features/reports/forms/locale/ThemeForm.locale").I18n
     | import("../features/reports/locale/CenterMessage.locale").I18n
     | import("../features/reports/locale/CreateReport.locale").I18n

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -45,6 +45,7 @@ export type ComponentKey =
     | import("../features/reports/locale/CreateReport.locale").I18n
     | import("../features/reports/locale/EditReport.locale").I18n
     | import("../features/reports/locale/ShowReport.locale").I18n
+    | import("../features/reports/locale/ConfirmDeleteShareReportModal.locale").I18n
     | import("../features/reports/locale/ReportTracking.locale").I18n
     | import("../features/working-layer/forms/locale/ShowFeatureTypeForm.locale").I18n
     | import("../features/working-layer/modal/locale/ClickableFeaturesModal.locale").I18n

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -45,6 +45,7 @@ export type ComponentKey =
     | import("../features/reports/locale/CreateReport.locale").I18n
     | import("../features/reports/locale/EditReport.locale").I18n
     | import("../features/reports/locale/ShowReport.locale").I18n
+    | import("../features/reports/locale/ReportDrawer.locale").I18n
     | import("../features/reports/locale/ConfirmDeleteShareReportModal.locale").I18n
     | import("../features/reports/locale/ReportTracking.locale").I18n
     | import("../features/working-layer/forms/locale/ShowFeatureTypeForm.locale").I18n

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,11 @@
     display: flex;
     justify-content: end;
 }
+.drawer-close > button.ri-close-line {
+    flex-direction: row-reverse;
+    align-items: center;
+    gap: 8px;
+}
 
 .loader {
     position: absolute;

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 interface ModalState {
     replyReportModal: ReturnType<typeof createModal>;
     deleteReportModal: ReturnType<typeof createModal>;
+    deleteShareReportModal: ReturnType<typeof createModal>;
     confirmCancelModal: ReturnType<typeof createModal>;
     confirmResetContributionModal: ReturnType<typeof createModal>;
 }
@@ -11,6 +12,7 @@ interface ModalState {
 const modalConfigs = [
     { key: "replyReportModal", id: "answerreport-modal" },
     { key: "deleteReportModal", id: "deletereport-modal" },
+    { key: "deleteShareReportModal", id: "deletesharereport-modal" },
     { key: "confirmCancelModal", id: "cancelreport-modal" },
     { key: "confirmResetContributionModal", id: "confirm-reset-contribution-modal" },
 ];

--- a/src/store/useReportStore.ts
+++ b/src/store/useReportStore.ts
@@ -1,4 +1,4 @@
-import { CommunityReport, FilterState } from "@/constants/reports/types";
+import { CommunityReport, FilterState, SortType } from "@/constants/reports/types";
 import { Feature } from "ol";
 import { create } from "zustand";
 interface ReportStore {
@@ -30,8 +30,11 @@ interface ReportStore {
     setReportTableWidth: (reportTableWidth: number) => void;
     selectedLine: number;
     setSelectedLine: (selectedLine: number) => void;
-    sortBy: string | undefined;
+    sortOrder: "ASC" | "DESC" | undefined;
+    sortBy: string;
     setSortBy: (sortBy: string) => void;
+    setSortOrder: (order: "ASC" | "DESC") => void;
+    toggleSortByDateCreation: (order?: "ASC" | "DESC") => void;
     drawerOpened: boolean;
     setDrawerOpened: (drawerOpened: boolean) => void;
     responseDrawerOpened: boolean;
@@ -95,8 +98,17 @@ export const useReportStore = create<ReportStore>((set, get) => ({
     setReportTableWidth: (reportTableWidth: number) => set({ reportTableWidth }),
     selectedLine: 0,
     setSelectedLine: (selectedLine: number) => set({ selectedLine }),
-    sortBy: undefined,
+    sortOrder: undefined,
+    sortBy: "",
     setSortBy: (sortBy) => set({ sortBy }),
+    setSortOrder: (order) => set({ sortOrder: order }),
+    toggleSortByDateCreation: (order) => {
+        const { sortOrder, setSortBy, setCurrentPage, setSortOrder } = get();
+        const newOrder = order ?? (sortOrder === SortType.ASC ? SortType.DESC : SortType.ASC);
+        setSortBy(`opening_date:${newOrder}`);
+        setCurrentPage(1);
+        setSortOrder(newOrder);
+    },
     drawerOpened: false,
     setDrawerOpened: (drawerOpened: boolean) => set({ drawerOpened }),
     responseDrawerOpened: false,


### PR DESCRIPTION
⚠️ [DESIGN DU CONTENU DES ACCORDIONS À REVOIR] ⚠️

- Permettre l’enregistrement indépendant de chaque section.
- Dans la section "Suivi", déplacer le formulaire d’ajout de réponse (select + textarea) en haut de la section.

<img width="600" height="919" alt="image" src="https://github.com/user-attachments/assets/75c310b0-de24-42df-9be0-ebb3dc02308b" />

- Garder la section Thème ouverte par défaut.
- Restreindre la possibilité de modifier un signalement lorsque son statut est : _Pris en compte_, _Déjà pris en compte_ ou _Rejeté_. Exemple ci-dessous pour le status "PRIS EN COMPTE"

<img width="590" height="846" alt="image" src="https://github.com/user-attachments/assets/55161660-7d7b-470e-a09c-136fe4e0a995" />
 

- Ajout d’une section permettant de supprimer ou partager un signalement (fonctionnalité en cours de développement).

<img width="585" height="315" alt="image" src="https://github.com/user-attachments/assets/15243c48-2cbf-4c68-ae8e-11a2d80b41d9" />
<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/1cbb71aa-7549-4333-95f5-97f8215fca3c" />

- Lors de l’ajout d'un signalement, actualiser le tableau afin d’afficher immédiatement le signalement nouvellement ajouté.


Edit:

- Harmoniser les boutons des sections en utilisant les variantes Primary et Secondary.
- Ajouter la prise en charge d’un nouveau type de document : .jpeg.
- Dans le tableau des signalements, désactiver le bouton Répondre pour les statuts : Pris en compte, Déjà pris en compte et Rejeté lors d'un check.
<img width="1266" height="329" alt="image" src="https://github.com/user-attachments/assets/78bddb2b-f47f-4c40-8796-da9c2d7a39db" />

- Dans la section Suivi, désactiver le bouton Envoyer tant que l’utilisateur n’a pas modifié le statut.

<img width="578" height="847" alt="image" src="https://github.com/user-attachments/assets/c000aca7-a350-4ec4-b14b-c5d6fadb7e13" />
