### PR TITLE
fix(no base map)

### DIFF
--- a/src/api/communityData.ts
+++ b/src/api/communityData.ts
@@ -6,7 +6,7 @@ import { getGeoserviceAll } from "./geoservicesData";
 import { Community, CommunityGeoservice, CommunityLayer, layerData } from "@/constants/communities/types";
 import { axiosApi } from ".";
 import { getFeatureTypesAll } from "./featureTypesData";
-import { LAYER_FEATURE_TYPE } from "@/constants";
+import { LAYER_FEATURE_TYPE, DEFAULT_COMMUNITY_MIN_ZOOM, DEFAULT_COMMUNITY_MAX_ZOOM } from "@/constants";
 
 let queryClient: QueryClient;
 
@@ -90,6 +90,8 @@ async function getCommunityById(communityId: string): Promise<[Community, Commun
         themes: res.data.attributes,
         position: res.data.position,
         zoom: res.data.zoom,
+        minZoom: res.data.min_zoom != null ? Number(res.data.min_zoom) : DEFAULT_COMMUNITY_MIN_ZOOM,
+        maxZoom: res.data.max_zoom != null ? Number(res.data.max_zoom) : DEFAULT_COMMUNITY_MAX_ZOOM,
     };
     const communityLayersKey = [`COMMUNITY_LAYERS_DATA_${communityId}`];
     let layers: CommunityLayer[];

--- a/src/constants/communities/types.ts
+++ b/src/constants/communities/types.ts
@@ -167,6 +167,8 @@ export interface Community {
     themes: CommunityTheme[];
     position: PointString;
     zoom: number;
+    minZoom: number;
+    maxZoom: number;
 }
 
 export const enum StatusMessage {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,3 +17,6 @@ export const TILE_SIZE = 2048;
 export const TILE_MAX_FEATURES = 5000;
 
 export const APP_FOOTER_MIN_HEIGHT = 40;
+
+export const DEFAULT_COMMUNITY_MIN_ZOOM = 4;
+export const DEFAULT_COMMUNITY_MAX_ZOOM = 20;

--- a/src/constants/localStorage/types.ts
+++ b/src/constants/localStorage/types.ts
@@ -11,5 +11,7 @@ export interface LocalStorageData {
     center: number[];
     layers: LocalLayer[];
     zoom: number;
+    minZoom: number;
+    maxZoom: number;
     projection: string;
 }

--- a/src/features/navigation/MainMap.tsx
+++ b/src/features/navigation/MainMap.tsx
@@ -96,6 +96,8 @@ export default function MainMap() {
             projection: localStorageData?.projection || olDefaults.projection,
             center: localStorageData?.center || (getLonLatFromPoint(community?.position) as number[]),
             zoom: localStorageData?.zoom || community?.zoom,
+            minZoom: localStorageData?.minZoom || community?.minZoom,
+            maxZoom: localStorageData?.maxZoom || community?.maxZoom,
         });
 
         const switcher = layerSwitcherControl(mapLayers);

--- a/src/features/navigation/SaveViewHandler.tsx
+++ b/src/features/navigation/SaveViewHandler.tsx
@@ -31,6 +31,8 @@ const SaveViewHandler: React.FC = () => {
                 };
             }),
             zoom: view.getZoom() || 0,
+            minZoom: community.minZoom,
+            maxZoom: community.maxZoom,
             projection: view.getProjection().getCode(),
         };
         if (isEqual(newLocalStorageData, localStorageData)) return;


### PR DESCRIPTION
use community min/max zoom lvl or a default one, a basemap might always be visible.


Dans la plupart des guichets rencontrés, les lvl de zoom min et max n'étaient pas définis. On essaye au mieux de les utiliser, ou l'on passe par des valeurs par défaut dites raisonnables. 