### PR TITLE
fix: keep showing 'share' option in report for all users + rename mod…

### DIFF
--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -76,7 +76,7 @@ export const reportImgStatus: ReportImgStatusType = {
     test: { img: imgTest, text: "En mode test", colorType: "new" },
 };
 
-export const STATUS_NOT_ALLOWED = ["valid", "valid0", "reject", "test"];
+export const STATUS_NOT_ALLOWED = ["valid", "valid0", "reject", "reject0", "test"];
 type LonLatCoordinate = Coordinate | Coordinate[] | Coordinate[][] | Coordinate[][][];
 type FeatureTypeData = { geometrie: string; capacite: number | null; type_amenagement: string | null };
 

--- a/src/features/reports/DeleteShareReportComponent.tsx
+++ b/src/features/reports/DeleteShareReportComponent.tsx
@@ -1,14 +1,24 @@
 import Button from "@codegouvfr/react-dsfr/Button";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import ConfirmDeleteShareReportModal from "./ConfirmDeleteShareReportModal";
-import { useModalStore } from "@/store";
+import { useCommunityStore, useModalStore } from "@/store";
 import ShareReportModal from "./ShareReportModal";
+import { useGetUserProfileAPI } from "@/api/userData";
 interface Props {
     handleDelete: () => void;
 }
 const DeleteShareReportComponent = ({ handleDelete }: Props) => {
     const [showActions, setShowActions] = useState<boolean>(false);
     const { deleteShareReportModal, shareReport } = useModalStore();
+
+    const { community } = useCommunityStore();
+
+    const { data: userData } = useGetUserProfileAPI();
+    const isAdmin = useMemo(() => {
+        const currentUser = userData?.communitiesMember?.filter((cm) => cm.communityId === community?.id);
+        return Array.isArray(currentUser) ? currentUser.some((role) => role.role === "admin") : false;
+    }, [userData, community?.id]);
+
     return (
         <div className="report-deleteShare__wrapper">
             <Button
@@ -20,9 +30,11 @@ const DeleteShareReportComponent = ({ handleDelete }: Props) => {
 
             {showActions && (
                 <div className="report-deleteShare__container">
-                    <Button priority="tertiary no outline" nativeButtonProps={deleteShareReportModal.buttonProps}>
-                        Supprimer
-                    </Button>
+                    {isAdmin && (
+                        <Button priority="tertiary no outline" nativeButtonProps={deleteShareReportModal.buttonProps}>
+                            Supprimer
+                        </Button>
+                    )}
                     <Button priority="tertiary no outline" nativeButtonProps={shareReport.buttonProps}>
                         Partager
                     </Button>

--- a/src/features/reports/EditReport.tsx
+++ b/src/features/reports/EditReport.tsx
@@ -1,16 +1,16 @@
 import { useTranslation } from "@/i18n";
 import { Feature } from "ol";
-import VectorSource from "ol/source/Vector";
-import { deleteCommunityReportAPI, updateCommunityReport } from "@/api/reportsData";
-import { deleteCommunityReportAllAttachments, postCommunityReportAttachments } from "@/api/attachmentData";
+import { updateCommunityReport } from "@/api/reportsData";
+import { postCommunityReportAttachments } from "@/api/attachmentData";
 import { useCommunityStore, useMapStore, useReportStore } from "@/store";
 import { CommunityTheme, StatusMessage } from "@/constants/communities/types";
 import { PostReport, PostThemeReport } from "@/constants/reports/types";
-import { clearDrawingLayer, getFeatureGeometryWKT } from "@/constants/utils";
-import { getReportSketch, REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
+import { getFeatureGeometryWKT } from "@/constants/utils";
+import { getReportSketch } from "@/constants/reports/utils";
 import ReportForm from "./forms/ReportForm";
 import { useCallback } from "react";
 import Button from "@codegouvfr/react-dsfr/Button";
+import { useDeleteReport } from "@/hooks/reports/useDeleteReport";
 
 interface Props {
     handleCloseDrawer: () => void;
@@ -59,39 +59,9 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
         [community, selectedReport, reports, addAlertMessage, t, setReports]
     );
 
+    const { deleteReport } = useDeleteReport({ handleCloseDrawer });
+
     if (!community || !map || !selectedReport) return null;
-
-    const handleDeleteReport = async () => {
-        try {
-            const attachmentsDeleted = await deleteCommunityReportAllAttachments(selectedReport);
-            if (!attachmentsDeleted) {
-                addAlertMessage(StatusMessage.error, t("report_document_deleted_error"));
-                return;
-            }
-
-            const reportDeleted = await deleteCommunityReportAPI(selectedReport);
-            if (!reportDeleted) {
-                addAlertMessage(StatusMessage.error, t("report_deleted_error"));
-                return;
-            }
-            addAlertMessage(StatusMessage.success, t("report_deleted_success", { reportId: selectedReport.id }));
-            const reportLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
-            const reportSource = reportLayer?.getSource() as VectorSource;
-
-            const filteredFeatures = reportSource.getFeatures().filter((f) => {
-                const reportData = f.get("reportData");
-                return reportData?.id === selectedReport.id;
-            });
-
-            reportSource.removeFeatures(filteredFeatures);
-            setReports([...reports.filter((report) => report.id !== selectedReport.id)], true);
-            handleCloseDrawer();
-            clearDrawingLayer(map);
-        } catch {
-            addAlertMessage(StatusMessage.error, t("report_document_deleted_error"));
-            throw new Error();
-        }
-    };
 
     const handleUpdateReport = async (
         selectedTheme: CommunityTheme,
@@ -187,7 +157,7 @@ const EditReport: React.FC<Props> = ({ handleCloseDrawer }) => {
             </Button>
             <ReportForm
                 handleClose={handleCloseEditReportDrawer}
-                handleDelete={handleDeleteReport}
+                handleDelete={() => deleteReport(selectedReport!)}
                 handleSubmit={handleUpdateReport}
                 handleSubmitSketch={handleUpdateReportSketch}
                 handleSubmitTheme={handleUpdateReportTheme}

--- a/src/features/reports/ShareReportFiltersModal.tsx
+++ b/src/features/reports/ShareReportFiltersModal.tsx
@@ -32,11 +32,11 @@ const ShareReportFiltersModal = () => {
     };
 
     return (
-        <ModaleComponent modal={shareReportFilters} title={t("share_title")}>
+        <ModaleComponent modal={shareReportFilters} title={t("share_title_reports")}>
             {showToast && <Tag className="shareReport__copiedLink">{t("copied_link")}</Tag>}
             <div className="shareReport__container">
                 <div className="shareReport__subTitle">
-                    <p>{t("report_link")}</p>
+                    <p>{t("reports_link")}</p>
                     <Button
                         iconId="ri-file-copy-line"
                         priority="tertiary"
@@ -59,7 +59,7 @@ const ShareReportFiltersModal = () => {
                         value: url,
                     }}
                     state="info"
-                    stateRelatedMessage={t("report_modalInfo")}
+                    stateRelatedMessage={t("reports_modalInfo")}
                 />
             </div>
         </ModaleComponent>

--- a/src/features/reports/ShareReportModal.tsx
+++ b/src/features/reports/ShareReportModal.tsx
@@ -41,7 +41,7 @@ const ShareReportModal = () => {
     };
 
     return (
-        <ModaleComponent modal={shareReport} title={t("share_title")}>
+        <ModaleComponent modal={shareReport} title={t("share_title_report")}>
             {showToast && <Tag className="shareReport__copiedLink">{t("copied_link")}</Tag>}
             <div className="shareReport__container">
                 <div className="shareReport__subTitle">

--- a/src/features/reports/ShowReport.tsx
+++ b/src/features/reports/ShowReport.tsx
@@ -12,14 +12,19 @@ import AttachmentList from "./forms/AttachmentList";
 import ReportTracking from "./ReportTracking";
 import DrawingForm from "./forms/DrawingForm";
 import { STATUS_NOT_ALLOWED } from "@/constants/utils";
+import DeleteShareReportComponent from "./DeleteShareReportComponent";
+import LoaderComponent from "@/components/LoaderComponent";
+
+import { useDeleteReport } from "@/hooks/reports/useDeleteReport";
 interface Props {
     handleCloseDrawer: () => void;
 }
 
-const ShowReport: React.FC<Props> = () => {
+const ShowReport: React.FC<Props> = ({ handleCloseDrawer }) => {
     const [openSuivi, setOpenSuivi] = useState(false);
     const [committedStatus, setCommittedStatus] = useState("");
 
+    const [loading] = useState<boolean>(false);
     const { selectedReport, setTableDrawerOpened, setDrawerOpened } = useReportStore();
     const { clickedTool, setClickedTool } = useMapStore();
     const { community } = useCommunityStore();
@@ -45,6 +50,7 @@ const ShowReport: React.FC<Props> = () => {
         }
     }, []);
 
+    const { deleteReport } = useDeleteReport({ handleCloseDrawer });
     if (!community || !selectedReport) return null;
 
     const selectedTheme = selectedReport.themes[0];
@@ -66,10 +72,14 @@ const ShowReport: React.FC<Props> = () => {
                 {t("report_back")}
             </Button>
             <div className="report-drawer">
-                <h2 className="fr-mt-4v fr-mb-1v fr-text--md">
-                    <span className="ri-map-pin-add-line fr-pr-1v" />
-                    {t("report_title", { reportId: selectedReport.id })}
-                </h2>
+                {loading && <LoaderComponent />}
+                <div className="report-drawer__container">
+                    <h2 className="fr-mt-4v fr-mb-1v fr-text--md">
+                        <span className="ri-map-pin-add-line fr-pr-1v" />
+                        {t("report_title", { reportId: selectedReport.id })}
+                    </h2>
+                    <DeleteShareReportComponent handleDelete={() => deleteReport(selectedReport!)} />
+                </div>
                 <ReportFiltersComponent reportStatus={committedStatus} />
                 {!STATUS_NOT_ALLOWED.includes(selectedReport.status) && (
                     <Button

--- a/src/features/reports/forms/ReportForm.tsx
+++ b/src/features/reports/forms/ReportForm.tsx
@@ -21,7 +21,6 @@ import AttachmentList from "./AttachmentList";
 import ReportTracking from "../ReportTracking";
 import ThemeComponent from "./ThemeComponent";
 import DeleteShareReportComponent from "../DeleteShareReportComponent";
-import { useGetUserProfileAPI } from "@/api/userData";
 
 const allowedTypes = ["image/png", "image/jpg", "image/jpeg", "application/pdf"];
 const maxSizeMB = 3;
@@ -79,7 +78,6 @@ const ReportForm: React.FC<Props> = ({
     const handleToolClickRef = useRef<((tool: ReportTool | undefined) => void) | null>(null);
 
     const { community } = useCommunityStore();
-    const { data: userData } = useGetUserProfileAPI();
 
     const { editReport, selectedReport, selectedFeatures, setSelectedFeatures, setTableDrawerOpened, setDrawerOpened, toggleSortByDateCreation } =
         useReportStore();
@@ -375,11 +373,6 @@ const ReportForm: React.FC<Props> = ({
         setThemeAttributes(attributes);
     };
 
-    const isAdmin = useMemo(() => {
-        const currentUser = userData?.communitiesMember?.filter((cm) => cm.communityId === community?.id);
-        return Array.isArray(currentUser) ? currentUser.some((role) => role.role === "admin") : false;
-    }, [userData, community?.id]);
-
     if (!community) return;
 
     return (
@@ -390,7 +383,7 @@ const ReportForm: React.FC<Props> = ({
                     <h2 className="ri-map-pin-add-line fr-mt-4v fr-mb-1v fr-text--md">
                         {selectedReport ? t("edit_report_title", { reportId: selectedReport.id }) : t("create_report_title")}
                     </h2>
-                    {editReport && isAdmin && <DeleteShareReportComponent handleDelete={onDelete} />}
+                    {editReport && <DeleteShareReportComponent handleDelete={onDelete} />}
                 </div>
                 {selectedReport && <ReportFiltersComponent reportStatus={committedStatus} />}
                 {!selectedReport && (

--- a/src/features/reports/locale/ShareReportModal.locale.tsx
+++ b/src/features/reports/locale/ShareReportModal.locale.tsx
@@ -2,26 +2,41 @@ import { Translations } from "@/i18n/types";
 import { declareComponentKeys } from "i18nifty";
 
 export const ShareReportModalFrTranslations: Translations<"fr">["ShareReportModal"] = {
-    share_title: "Partager le signalement",
+    share_title_report: "Partager le signalement",
+    share_title_reports: "Partager les signalements",
     report_link: "Lien du signalement",
+    reports_link: "Lien vers la liste des signalements",
     report_copyLink: "Copier",
     share_url: "URL à intégrer",
     copied_link: "Lien copié",
     erorr_copiedLink: "Le lien n'a pas été copié correctement.",
     report_modalInfo: "Seuls les membres du guichet pourront accéder à ce signalement en utilisant ce lien.",
+    reports_modalInfo: "Seuls les membres du guichet pourront accéder à la liste des signalements en utilisant ce lien",
 };
 
 export const ShareReportModalEnTranslations: Translations<"en">["ShareReportModal"] = {
-    share_title: "Share the report",
+    share_title_report: "Share the report",
+    share_title_reports: "Share the reports",
     report_link: "Report link",
+    reports_link: "Link to the list of reports",
     report_copyLink: "Copy",
     share_url: "URL to integrate",
     copied_link: "link copied",
     erorr_copiedLink: "The link was not copied correctly.",
     report_modalInfo: "Only members of the help desk will be able to access this report using this link.",
+    reports_modalInfo: "Only members of the help desk will be able to access the list of reports using this link.",
 };
 
 const { i18n } = declareComponentKeys<
-    "share_title" | "report_link" | "report_copyLink" | "share_url" | "copied_link" | "erorr_copiedLink" | "report_modalInfo"
+    | "share_title_report"
+    | "share_title_reports"
+    | "report_link"
+    | "reports_link"
+    | "report_copyLink"
+    | "share_url"
+    | "copied_link"
+    | "erorr_copiedLink"
+    | "report_modalInfo"
+    | "reports_modalInfo"
 >()("ShareReportModal");
 export type I18n = typeof i18n;

--- a/src/features/reports/locale/ShowReport.locale.tsx
+++ b/src/features/reports/locale/ShowReport.locale.tsx
@@ -14,6 +14,9 @@ export const ShowReportFrTranslations: Translations<"fr">["ShowReport"] = {
     report_content: "Votre message",
     report_send: "Envoyer",
     report_reply: "Répondre",
+    report_document_deleted_error: "Erreur dans la suppression des documents du signalement !",
+    report_deleted_error: "Erreur dans la suppression du signalement !",
+    report_deleted_success: ({ reportId }: { reportId: number }) => `Le signalement ${reportId} est supprimé avec succès.`,
 };
 
 export const ShowReportEnTranslations: Translations<"en">["ShowReport"] = {
@@ -29,6 +32,9 @@ export const ShowReportEnTranslations: Translations<"en">["ShowReport"] = {
     report_content: "Your message",
     report_send: "Send",
     report_reply: "Reply",
+    report_document_deleted_error: "Error deleting documents from the report!",
+    report_deleted_error: "Error deleting report!",
+    report_deleted_success: ({ reportId }: { reportId: number }) => `Report ${reportId} is successfully deleted.`,
 };
 
 const { i18n } = declareComponentKeys<
@@ -44,5 +50,8 @@ const { i18n } = declareComponentKeys<
     | "report_content"
     | "report_reply"
     | "report_send"
+    | "report_document_deleted_error"
+    | "report_deleted_error"
+    | { K: "report_deleted_success"; P: { reportId: number }; R: string }
 >()("ShowReport");
 export type I18n = typeof i18n;

--- a/src/hooks/reports/locale/useDeleteReport.locale.tsx
+++ b/src/hooks/reports/locale/useDeleteReport.locale.tsx
@@ -1,0 +1,19 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const useDeleteReportFrTranslations: Translations<"fr">["useDeleteReport"] = {
+    report_document_deleted_error: "Erreur dans la suppression des documents du signalement !",
+    report_deleted_error: "Erreur dans la suppression du signalement !",
+    report_deleted_success: ({ reportId }: { reportId: number }) => `Le signalement ${reportId} est supprimé avec succès.`,
+};
+
+export const useDeleteReportEnTranslations: Translations<"en">["useDeleteReport"] = {
+    report_document_deleted_error: "Error deleting documents from the report!",
+    report_deleted_error: "Error deleting report!",
+    report_deleted_success: ({ reportId }: { reportId: number }) => `Report ${reportId} is successfully deleted.`,
+};
+
+const { i18n } = declareComponentKeys<
+    "report_document_deleted_error" | "report_deleted_error" | { K: "report_deleted_success"; P: { reportId: number }; R: string }
+>()("useDeleteReport");
+export type I18n = typeof i18n;

--- a/src/hooks/reports/useDeleteReport.tsx
+++ b/src/hooks/reports/useDeleteReport.tsx
@@ -1,0 +1,60 @@
+import { useCallback } from "react";
+import { useCommunityStore, useMapStore, useReportStore } from "@/store";
+import { useTranslation } from "@/i18n";
+import { StatusMessage } from "@/constants/communities/types";
+import { deleteCommunityReportAPI } from "@/api/reportsData";
+import { clearDrawingLayer } from "@/constants/utils";
+import VectorSource from "ol/source/Vector";
+import type { CommunityReport } from "@/constants/reports/types";
+import { REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
+
+interface UseDeleteReportProps {
+    handleCloseDrawer?: () => void; // Optionnel
+}
+
+export const useDeleteReport = ({ handleCloseDrawer }: UseDeleteReportProps) => {
+    const { addAlertMessage } = useCommunityStore();
+    const { t } = useTranslation({ useDeleteReport });
+    const { map } = useMapStore();
+    const { reports, setReports, setDrawerOpened } = useReportStore();
+
+    const deleteReport = useCallback(
+        async (report: CommunityReport) => {
+            try {
+                const reportDeleted = await deleteCommunityReportAPI(report);
+                if (!reportDeleted) {
+                    addAlertMessage(StatusMessage.error, t("report_deleted_error"));
+                    return false;
+                }
+
+                addAlertMessage(StatusMessage.success, t("report_deleted_success", { reportId: report.id }));
+
+                const reportLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
+                const reportSource = reportLayer?.getSource() as VectorSource;
+                if (reportSource) {
+                    const filteredFeatures = reportSource.getFeatures().filter((f) => {
+                        const reportData = f.get("reportData") as CommunityReport | undefined;
+                        return reportData?.id === report.id;
+                    });
+                    reportSource.removeFeatures(filteredFeatures);
+                }
+
+                setReports(
+                    reports.filter((r) => r.id !== report.id),
+                    true
+                );
+                handleCloseDrawer?.();
+                setDrawerOpened(false);
+                clearDrawingLayer(map);
+                return true;
+            } catch (error) {
+                addAlertMessage(StatusMessage.error, t("report_document_deleted_error"));
+                console.error("Delete report error:", error);
+                return false;
+            }
+        },
+        [addAlertMessage, map, reports, setReports, t, setDrawerOpened]
+    );
+
+    return { deleteReport };
+};

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -36,6 +36,7 @@ import { CatalogControlEnTranslations } from "@/features/navigation/controls/loc
 import { CenterReportControlEnTranslations } from "@/features/navigation/controls/cusom-controls/locale/CenterReportControl.locale";
 import { useGetMapControlsEnTranslations } from "@/features/navigation/controls/locale/useGetMapControls.locale";
 import { useReportToolsEnTranslations } from "@/hooks/reports/locale/useReportTools.locale";
+import { useDeleteReportEnTranslations } from "@/hooks/reports/locale/useDeleteReport.locale";
 import { FeatureTypeLayerLegendsEnTranslations } from "@/features/navigation/layers/legends/locale/FeatureTypeLayerLegends.locale";
 import { ShowFeatureTypeFormEnTranslations } from "@/features/working-layer/forms/locale/ShowFeatureTypeForm.locale";
 import { EditFeatureTypeFormEnTranslations } from "@/features/working-layer/forms/locale/EditFeatureTypeForm.locale";
@@ -94,6 +95,7 @@ export const translations: Translations<"en"> = {
     CenterReportControl: CenterReportControlEnTranslations,
     useGetMapControls: useGetMapControlsEnTranslations,
     useReportTools: useReportToolsEnTranslations,
+    useDeleteReport: useDeleteReportEnTranslations,
     FeatureTypeLayerLegends: FeatureTypeLayerLegendsEnTranslations,
     ShowFeatureTypeForm: ShowFeatureTypeFormEnTranslations,
     EditFeatureTypeForm: EditFeatureTypeFormEnTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -36,6 +36,7 @@ import { CatalogControlFrTranslations } from "@/features/navigation/controls/loc
 import { CenterReportControlFrTranslations } from "@/features/navigation/controls/cusom-controls/locale/CenterReportControl.locale";
 import { useGetMapControlsFrTranslations } from "@/features/navigation/controls/locale/useGetMapControls.locale";
 import { useReportToolsFrTranslations } from "@/hooks/reports/locale/useReportTools.locale";
+import { useDeleteReportFrTranslations } from "@/hooks/reports/locale/useDeleteReport.locale";
 import { FeatureTypeLayerLegendsFrTranslations } from "@/features/navigation/layers/legends/locale/FeatureTypeLayerLegends.locale";
 import { ShowFeatureTypeFormFrTranslations } from "@/features/working-layer/forms/locale/ShowFeatureTypeForm.locale";
 import { EditFeatureTypeFormFrTranslations } from "@/features/working-layer/forms/locale/EditFeatureTypeForm.locale";
@@ -94,6 +95,7 @@ export const translations: Translations<"fr"> = {
     CenterReportControl: CenterReportControlFrTranslations,
     useGetMapControls: useGetMapControlsFrTranslations,
     useReportTools: useReportToolsFrTranslations,
+    useDeleteReport: useDeleteReportFrTranslations,
     FeatureTypeLayerLegends: FeatureTypeLayerLegendsFrTranslations,
     ShowFeatureTypeForm: ShowFeatureTypeFormFrTranslations,
     EditFeatureTypeForm: EditFeatureTypeFormFrTranslations,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -66,6 +66,7 @@ export type ComponentKey =
     | import("../hooks/navigation/layers/locale/useGetWMSLayer.locale").I18n
     | import("../hooks/navigation/layers/locale/useGetWMTSLayer.locale").I18n
     | import("../hooks/reports/locale/useReportTools.locale").I18n
+    | import("../hooks/reports/locale/useDeleteReport.locale").I18n
     | import("../hooks/working-layer/locale/useFeatureTypeValidation.locale").I18n
     | import("../features/reports/forms/locale/FormAttachments.locale").I18n;
 


### PR DESCRIPTION
<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/84954e29-b424-44b0-a15c-9f09837c959d" />
<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/e4542afa-83f9-4ecf-9543-830d440e4621" />
si non admin, continuer d'afficher le partage sans l'option 'supprimer':
<img width="1336" height="597" alt="Screenshot from 2026-01-07 11-25-43" src="https://github.com/user-attachments/assets/0b665399-7bc6-4825-9f88-8bf249484207" />
