### PR TITLE
feat: add 'table=reports' param when reports

### DIFF
--- a/src/components/FilterAndSortReport.tsx
+++ b/src/components/FilterAndSortReport.tsx
@@ -201,18 +201,18 @@ const FilterAndSortReport = () => {
         <>
             <form ref={formRef} className="filter-report">
                 <div>
-                    <p className="report-subTitle">Trier par : </p>
+                    <p className="report-subTitle">{t("sortBy")}: </p>
                     <div className="sort-report__wrapper">
                         <SelectComponent
                             name="sortByDateCreation"
-                            label="Date de création"
+                            label={t("dateCreation")}
                             value={sortOpeningDateIndex}
                             options={sortOptions}
                             onChange={onChangeOpeningDate}
                         />
                         <SelectComponent
                             name="sortByDateMAJ"
-                            label="Date de mise à jour"
+                            label={t("dateUpdating")}
                             value={sortUpdatingDateIndex}
                             options={sortOptions}
                             onChange={onChangeUpdatingDate}
@@ -221,13 +221,13 @@ const FilterAndSortReport = () => {
                 </div>
 
                 <div>
-                    <p className="report-subTitle">Filtrer par :</p>
+                    <p className="report-subTitle">{t("filterBy")}: </p>
                     <div className="filter-report__wrapper">
                         <SelectComponent
                             name="status"
                             label="Statut"
                             value={statusIndex}
-                            defaultOption="Sélectionner une option"
+                            defaultOption={t("selectOption")}
                             options={statusOptions}
                             onChange={setStatusIndex}
                         />
@@ -235,7 +235,7 @@ const FilterAndSortReport = () => {
                             name="theme"
                             label="Thème"
                             value={themeIndex}
-                            defaultOption="Sélectionner une option"
+                            defaultOption={t("selectOption")}
                             options={themeOptions}
                             onChange={setThemeIndex}
                         />
@@ -255,7 +255,7 @@ const FilterAndSortReport = () => {
                             className="filter-report__select"
                             label="Département"
                             nativeInputProps={{
-                                placeholder: "Sélectionner une option",
+                                placeholder: t("selectOption"),
                                 name: "departement",
                                 type: "number",
                                 max: 2,
@@ -268,10 +268,10 @@ const FilterAndSortReport = () => {
 
                 <div className="sumbit">
                     <Button type="submit" onClick={resetFiltersAndSort} priority="secondary">
-                        Effacer
+                        {t("reset")}
                     </Button>
                     <Button type="submit" onClick={handleSubmit}>
-                        Appliquer
+                        {t("apply")}
                     </Button>
                 </div>
             </form>

--- a/src/components/locale/FilterAndSortReport.locale.tsx
+++ b/src/components/locale/FilterAndSortReport.locale.tsx
@@ -2,16 +2,32 @@ import { Translations } from "@/i18n/types";
 import { declareComponentKeys } from "i18nifty";
 
 export const FilterAndSortReportFrTranslations: Translations<"fr">["FilterAndSortReport"] = {
+    apply: "Appliquer",
+    dateCreation: "Date de création",
+    dateUpdating: "Date de mise à jour",
+    filterBy: "Trier par",
+    sortBy: "Trier par",
+    reset: "Effacer",
+    selectOption: "Sélectionner une option",
     newToOld: "Du plus récent au plus ancien",
     oldToNew: "Du plus ancien au plus récent",
     loading_error: "Erreur lors du chargement des signalements.",
 };
 
 export const FilterAndSortReportEnTranslations: Translations<"en">["FilterAndSortReport"] = {
+    apply: "Apply",
+    filterBy: "Filter by",
+    sortBy: "Sort by",
+    reset: "Reset",
+    selectOption: "Select an option",
+    dateCreation: "Creation date",
+    dateUpdating: "Updating date",
     newToOld: "From newest to oldest",
     oldToNew: "From oldest to newest",
     loading_error: "Error loading reports.",
 };
 
-const { i18n } = declareComponentKeys<"newToOld" | "oldToNew" | "loading_error">()("FilterAndSortReport");
+const { i18n } = declareComponentKeys<
+    "newToOld" | "oldToNew" | "loading_error" | "apply" | "filterBy" | "sortBy" | "dateCreation" | "dateUpdating" | "selectOption" | "reset"
+>()("FilterAndSortReport");
 export type I18n = typeof i18n;

--- a/src/features/reports/ShareReportFiltersModal.tsx
+++ b/src/features/reports/ShareReportFiltersModal.tsx
@@ -8,7 +8,6 @@ import Tag from "@codegouvfr/react-dsfr/Tag";
 import { layerData, StatusMessage } from "@/constants/communities/types";
 import ShareReportModal from "./ShareReportModal";
 import { LAYER_FEATURE_TYPE } from "@/constants";
-import { getFeatureTypeById } from "@/api/featureTypesData";
 
 const ShareReportFiltersModal = () => {
     const [showToast, setShowToast] = useState<boolean>(false);
@@ -18,7 +17,7 @@ const ShareReportFiltersModal = () => {
 
     const { addAlertMessage, communityLayers } = useCommunityStore();
     const { shareReportFilters } = useModalStore();
-    const { activeTable, setActiveTable, syncUrlFromState } = useReportStore();
+    const { activeTable, syncUrlFromState } = useReportStore();
 
     const baseUrl = useMemo(() => `${window.location.origin}${window.location.pathname}`, []);
     const url = useMemo(() => baseUrl + syncUrlFromState(), [baseUrl, syncUrlFromState]);
@@ -26,26 +25,9 @@ const ShareReportFiltersModal = () => {
     const currentGeoservice = useMemo(() => communityLayers?.find((layer: layerData) => layer.type === LAYER_FEATURE_TYPE), [communityLayers]);
 
     useEffect(() => {
-        if (!currentGeoservice?.database || !currentGeoservice?.table) return;
-
-        async function directTable() {
-            const featureTypeId = {
-                database: currentGeoservice?.database || null,
-                table: currentGeoservice?.table || null,
-            };
-
-            const res = await getFeatureTypeById(featureTypeId);
-            const fullName = res.data.full_name;
-            setActiveTable(fullName);
-        }
-        directTable();
-    }, [currentGeoservice, setActiveTable]);
-
-    useEffect(() => {
         const baseParams = new URL(url).search;
-        const tableParam = currentGeoservice?.database ? `&table=${activeTable}` : "&table=reports";
 
-        const newUrl = `${baseUrl}${baseParams}${tableParam}`;
+        const newUrl = `${baseUrl}${baseParams}&view=reports`;
         setShareUrl(newUrl);
     }, [activeTable, baseUrl, currentGeoservice, url]);
 

--- a/src/features/reports/ShareReportFiltersModal.tsx
+++ b/src/features/reports/ShareReportFiltersModal.tsx
@@ -43,8 +43,10 @@ const ShareReportFiltersModal = () => {
 
     useEffect(() => {
         const baseParams = new URL(url).search;
-        const tableParam = currentGeoservice?.database ? `&table=${activeTable}` : "";
-        setShareUrl(`${baseUrl}${baseParams}${tableParam}`);
+        const tableParam = currentGeoservice?.database ? `&table=${activeTable}` : "&table=reports";
+
+        const newUrl = `${baseUrl}${baseParams}${tableParam}`;
+        setShareUrl(newUrl);
     }, [activeTable, baseUrl, currentGeoservice, url]);
 
     const handleCopy = async () => {

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -94,8 +94,7 @@ const TableReport = () => {
         enabled: !!community,
     });
 
-    const reports = useMemo(() => data?.data ?? [], [data]);
-
+    const reports = useMemo(() => (Array.isArray(data?.data) ? data.data : []), [data]);
     const total = data?.total ?? 10;
     const totalPages = Math.ceil(total / limitPerPage);
     const { data: exportedData } = useQuery({

--- a/src/features/working-layer/modal/searchObjects/SearchObjectsModal.tsx
+++ b/src/features/working-layer/modal/searchObjects/SearchObjectsModal.tsx
@@ -37,7 +37,7 @@ const SearchObjectsModal = () => {
     const { map, mapWorkingLayer, setClickedControl } = useMapStore();
     const { searchModal } = useModalStore();
 
-    const geoservice = useMemo(() => communityLayers?.find((l) => l.geoservice.layer === mapWorkingLayer)?.geoservice, [communityLayers, mapWorkingLayer]);
+    const geoservice = useMemo(() => communityLayers?.find((l) => l?.geoservice?.layer === mapWorkingLayer)?.geoservice, [communityLayers, mapWorkingLayer]);
     const mapProjCode = useMemo(() => map?.getView()?.getProjection().getCode() ?? "EPSG:3857", [map]);
     const geoProjCode = useMemo(() => geoservice?.columns?.find((c) => c.name === geoservice?.geometryName)?.crs ?? "EPSG:3857", [geoservice]);
 

--- a/src/features/working-layer/modal/searchObjects/SearchTable.tsx
+++ b/src/features/working-layer/modal/searchObjects/SearchTable.tsx
@@ -43,7 +43,7 @@ const SearchTable: React.FC<Props> = ({ geoservice }) => {
     const mapProjCode = useMemo(() => map?.getView()?.getProjection().getCode() ?? "EPSG:3857", [map]);
     const geoProjCode = useMemo(() => geoservice?.columns?.find((c) => c.name === geoservice?.geometryName)?.crs ?? "EPSG:3857", [geoservice]);
 
-    const currentCommunityLayer = useMemo(() => communityLayers?.find((l) => l.geoservice.layer === mapWorkingLayer), [communityLayers, mapWorkingLayer]);
+    const currentCommunityLayer = useMemo(() => communityLayers?.find((l) => l?.geoservice?.layer === mapWorkingLayer), [communityLayers, mapWorkingLayer]);
 
     const sortedSearchResult = useMemo(
         () =>

--- a/src/hooks/navigation/controls/useCustomControlsList.ts
+++ b/src/hooks/navigation/controls/useCustomControlsList.ts
@@ -20,7 +20,7 @@ const useCustomControlsList = (t: TranslationFunction<"CustomControls", Componen
     const currentCommunityLayer = useMemo(() => communityLayers?.find((l) => l?.geoservice?.layer === mapWorkingLayer), [communityLayers, mapWorkingLayer]);
 
     const geoservice: CommunityGeoservice | undefined = useMemo(
-        () => communityLayers?.find((layer) => layer.geoservice.layer === mapWorkingLayer)?.geoservice,
+        () => communityLayers?.find((layer) => layer?.geoservice?.layer === mapWorkingLayer)?.geoservice,
         [communityLayers, mapWorkingLayer]
     );
 


### PR DESCRIPTION
`table=reports` quand on est sur les signalements (aucun layer vectoriel actif)

`table=XXX:xxx` quand un layer vectoriel avec base de données est actif

**Ex: guichet 2**
<img width="1320" height="861" alt="Screenshot from 2026-01-26 12-44-44" src="https://github.com/user-attachments/assets/ecd5e36d-d22e-4d51-b7f4-f1b54433a39e" />

**Ex: signalements:**
<img width="1320" height="861" alt="Screenshot from 2026-01-26 12-45-08" src="https://github.com/user-attachments/assets/516bc075-8965-414f-83ec-1f75ced98ad8" />
