### PR TITLE
Issue over report table

### DIFF
--- a/src/components/FilterAndSortReport.tsx
+++ b/src/components/FilterAndSortReport.tsx
@@ -165,7 +165,6 @@ const FilterAndSortReport = () => {
         const form = (e.target as HTMLButtonElement).form;
         if (!form) return;
         const formData = new FormData(form);
-
         const newFilters = {
             status: statusOptions[statusIndex] || "",
             theme: themeOptions[themeIndex] || "",
@@ -225,7 +224,7 @@ const FilterAndSortReport = () => {
                     <div className="filter-report__wrapper">
                         <SelectComponent
                             name="status"
-                            label="Statut"
+                            label={t("status")}
                             value={statusIndex}
                             defaultOption={t("selectOption")}
                             options={statusOptions}
@@ -233,7 +232,7 @@ const FilterAndSortReport = () => {
                         />
                         <SelectComponent
                             name="theme"
-                            label="Thème"
+                            label={t("theme")}
                             value={themeIndex}
                             defaultOption={t("selectOption")}
                             options={themeOptions}
@@ -242,24 +241,27 @@ const FilterAndSortReport = () => {
 
                         <Input
                             className="filter-report__select"
-                            label="Auteur"
+                            label={t("author")}
                             nativeInputProps={{
                                 name: "author",
                                 type: "number",
-                                inputMode: "numeric",
-                                pattern: "[0-9]*",
+                                min: 1,
+                                step: 1,
+                                placeholder: t("author_placeholder"),
                                 defaultValue: currentFilters.author ?? "",
+                                onBlur: (e) => {
+                                    e.currentTarget.value = String(parseInt(e.currentTarget.value, 10) || "");
+                                },
                             }}
                         />
                         <Input
                             className="filter-report__select"
-                            label="Département"
+                            label={t("departement")}
                             nativeInputProps={{
-                                placeholder: t("selectOption"),
+                                placeholder: t("depatement_placeholder"),
                                 name: "departement",
-                                type: "number",
-                                max: 2,
-                                multiple: true,
+                                type: "text",
+                                pattern: "^([02][1-9]|2[AB]|[1345678][0-9]|9[012345]|97[12346])$",
                                 defaultValue: currentFilters.departement ?? "",
                             }}
                         />

--- a/src/components/TransformReportsToTableData.tsx
+++ b/src/components/TransformReportsToTableData.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import VectorSource from "ol/source/Vector";
 import { handleShowOnMap } from "@/constants/utils";
 import { REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
@@ -15,15 +14,10 @@ const TransformReportsToTableData = (reports: CommunityReport[]) => {
     const { t } = useTranslation({ GetReportsLayer });
     const { localStorageData } = useLocalStorageStore();
     const { map } = useMapStore();
-    const { isChecked, setIsChecked, reportTableWidth, setSelectedLine, setSelectedReport } = useReportStore();
+    const { isChecked, setIsChecked, reportTableWidth, setSelectedReport } = useReportStore();
 
     const clusterLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);
     const clusterSource = clusterLayer?.getSource() as VectorSource;
-
-    useEffect(() => {
-        const renderSelectedLine = Object.values(isChecked).filter((val) => val === true).length;
-        setSelectedLine(renderSelectedLine);
-    }, [isChecked, setSelectedLine]);
 
     const showOnMap = (report: CommunityReport) => {
         setSelectedReport(report);

--- a/src/components/locale/FilterAndSortReport.locale.tsx
+++ b/src/components/locale/FilterAndSortReport.locale.tsx
@@ -12,6 +12,12 @@ export const FilterAndSortReportFrTranslations: Translations<"fr">["FilterAndSor
     newToOld: "Du plus récent au plus ancien",
     oldToNew: "Du plus ancien au plus récent",
     loading_error: "Erreur lors du chargement des signalements.",
+    status: "Statut",
+    theme: "Thème",
+    author: "Auteur",
+    departement: "Département",
+    depatement_placeholder: "Saisir un numéro de département",
+    author_placeholder: "Id uniquement",
 };
 
 export const FilterAndSortReportEnTranslations: Translations<"en">["FilterAndSortReport"] = {
@@ -25,9 +31,30 @@ export const FilterAndSortReportEnTranslations: Translations<"en">["FilterAndSor
     newToOld: "From newest to oldest",
     oldToNew: "From oldest to newest",
     loading_error: "Error loading reports.",
+    status: "Status",
+    theme: "Theme",
+    author: "Author",
+    departement: "(French) Department",
+    depatement_placeholder: "Enter a department number",
+    author_placeholder: "Id only",
 };
 
 const { i18n } = declareComponentKeys<
-    "newToOld" | "oldToNew" | "loading_error" | "apply" | "filterBy" | "sortBy" | "dateCreation" | "dateUpdating" | "selectOption" | "reset"
+    | "newToOld"
+    | "oldToNew"
+    | "loading_error"
+    | "apply"
+    | "filterBy"
+    | "sortBy"
+    | "dateCreation"
+    | "dateUpdating"
+    | "selectOption"
+    | "reset"
+    | "status"
+    | "theme"
+    | "author"
+    | "departement"
+    | "depatement_placeholder"
+    | "author_placeholder"
 >()("FilterAndSortReport");
 export type I18n = typeof i18n;

--- a/src/features/navigation/controls/custom-controls/ButtonControl.tsx
+++ b/src/features/navigation/controls/custom-controls/ButtonControl.tsx
@@ -18,8 +18,6 @@ const ButtonControl: React.FC<Props> = ({ control, onClick }) => {
             arrow
             title={showMapWorkingLayerSelect ? control.title : undefined}
             slots={{ transition: Fade }}
-            enterDelay={0}
-            leaveDelay={0}
             slotProps={{ tooltip: { onClick: () => onClick(control) } }}
             disableInteractive={control.disabled}
         >

--- a/src/features/navigation/layers/locale/GetReportsLayer.locale.tsx
+++ b/src/features/navigation/layers/locale/GetReportsLayer.locale.tsx
@@ -2,9 +2,12 @@ import { Translations } from "@/i18n/types";
 import { declareComponentKeys } from "i18nifty";
 
 export const GetReportsLayerFrTranslations: Translations<"fr">["GetReportsLayer"] = {
+    error: "Erreur lors du chargement des signalements",
     reports_title: "Signalements",
     reports_legend: "Légende signalements",
     report_reply: "Répondre",
+    selected_lines: "Nombre de lignes sélectionnée(s) :",
+    no_lines: "Pas de lignes sélectionnées",
     "tableHeaders.id": "Identifiant",
     "tableHeaders.status": "Statut",
     "tableHeaders.comment": "Commentaire",
@@ -20,9 +23,12 @@ export const GetReportsLayerFrTranslations: Translations<"fr">["GetReportsLayer"
 };
 
 export const GetReportsLayerEnTranslations: Translations<"en">["GetReportsLayer"] = {
+    error: "Error while loading reports",
     reports_title: "Reports",
     reports_legend: "Reports legend",
     report_reply: "Reply",
+    selected_lines: "Number of lines selected:",
+    no_lines: "No lines selected",
     "tableHeaders.id": "ID",
     "tableHeaders.status": "Status",
     "tableHeaders.comment": "Comment",
@@ -38,9 +44,12 @@ export const GetReportsLayerEnTranslations: Translations<"en">["GetReportsLayer"
 };
 
 const { i18n } = declareComponentKeys<
+    | "error"
     | "reports_title"
     | "reports_legend"
     | "report_reply"
+    | "selected_lines"
+    | "no_lines"
     | "tableHeaders.id"
     | "tableHeaders.status"
     | "tableHeaders.comment"

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -17,10 +17,11 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import { useTranslation } from "@/i18n";
 import MapListnerHandlers from "../navigation/controls/custom-controls/interactions/MapListnerHandlers";
 import { getCommunityReportById } from "@/api/reportsData";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 
 const ReportDrawer = () => {
     const { user } = useUserStore();
+    const navigate = useNavigate();
 
     const {
         reports,
@@ -50,6 +51,7 @@ const ReportDrawer = () => {
 
     const { data: userData } = useGetUserProfileAPI();
     const { t } = useTranslation({ ReportDrawer });
+    const [searchParams] = useSearchParams();
 
     const handleCloseDrawer = useCallback(() => {
         if (!selectedReport) {
@@ -76,6 +78,13 @@ const ReportDrawer = () => {
             removeAlertMessage(isNotified.id);
         }
 
+        if (searchParams.has("report")) {
+            const newParams = new URLSearchParams(searchParams);
+            newParams.delete("report");
+            const newSearch = newParams.toString();
+            navigate(newSearch ? `?${newSearch}` : window.location.pathname, { replace: true });
+        }
+
         showCenterReportButtons(false);
         setDrawerOpened(false);
         setEditReport(false);
@@ -85,6 +94,8 @@ const ReportDrawer = () => {
     }, [
         selectedReport,
         alertMessages,
+        searchParams,
+        navigate,
         setDrawerOpened,
         setEditReport,
         editReport,
@@ -161,7 +172,6 @@ const ReportDrawer = () => {
         }
     }, [drawerOpened, selectedReport, isAdmin, isOwner, setEditReport]);
 
-    const [searchParams] = useSearchParams();
     const reportIdParam = searchParams.get("report");
 
     const clusterLayer = map?.getAllLayers().find((layer) => layer.get("type") === REPORTS_LAYER_TYPE);

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -159,7 +159,7 @@ const ReportDrawer = () => {
         } else {
             setEditReport(false);
         }
-    }, [drawerOpened, selectedReport, isAdmin, isOwner, editReport]);
+    }, [drawerOpened, selectedReport, isAdmin, isOwner, setEditReport]);
 
     const [searchParams] = useSearchParams();
     const reportIdParam = searchParams.get("report");
@@ -178,11 +178,12 @@ const ReportDrawer = () => {
         if (hasReportParams()) {
             setTableDrawerOpened(true);
         }
-    }, [setTableDrawerOpened]);
+    }, [setTableDrawerOpened, setEditReport]);
 
     useEffect(() => {
         if (!reportIdParam) return;
-
+        setDrawerOpened(false);
+        setEditReport(false);
         const id = Number(reportIdParam);
         const local = reports.find((r) => Number(r.id) === id);
         if (local) {
@@ -194,11 +195,12 @@ const ReportDrawer = () => {
         (async () => {
             const report = await getCommunityReportById(id);
             if (report) {
+                setSelectedReport(report);
                 showOnMap(report);
                 setDrawerOpened(true);
             }
         })();
-    }, [reportIdParam, reports, setSelectedReport, setDrawerOpened, showOnMap]);
+    }, [reportIdParam, reports, setSelectedReport, setEditReport, setDrawerOpened, showOnMap]);
 
     return (
         <>

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -26,7 +26,6 @@ const ReportDrawer = () => {
     const {
         reports,
         selectedReport,
-        editReport,
         setEditReport,
         setSelectedReport,
         setSelectedFeatures,

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -78,13 +78,6 @@ const ReportDrawer = () => {
             removeAlertMessage(isNotified.id);
         }
 
-        if (searchParams.has("report")) {
-            const newParams = new URLSearchParams(searchParams);
-            newParams.delete("report");
-            const newSearch = newParams.toString();
-            navigate(newSearch ? `?${newSearch}` : window.location.pathname, { replace: true });
-        }
-
         showCenterReportButtons(false);
         setDrawerOpened(false);
         setEditReport(false);
@@ -94,8 +87,6 @@ const ReportDrawer = () => {
     }, [
         selectedReport,
         alertMessages,
-        searchParams,
-        navigate,
         setDrawerOpened,
         setEditReport,
         editReport,
@@ -199,6 +190,10 @@ const ReportDrawer = () => {
         if (local) {
             setSelectedReport(local);
             setDrawerOpened(true);
+            const newParams = new URLSearchParams(searchParams);
+            newParams.delete("report");
+            const newSearch = newParams.toString();
+            navigate(newSearch ? `?${newSearch}` : window.location.pathname, { replace: true });
             return;
         }
 
@@ -208,9 +203,13 @@ const ReportDrawer = () => {
                 setSelectedReport(report);
                 showOnMap(report);
                 setDrawerOpened(true);
+                const newParams = new URLSearchParams(searchParams);
+                newParams.delete("report");
+                const newSearch = newParams.toString();
+                navigate(newSearch ? `?${newSearch}` : window.location.pathname, { replace: true });
             }
         })();
-    }, [reportIdParam, reports, setSelectedReport, setEditReport, setDrawerOpened, showOnMap]);
+    }, [reportIdParam, reports, setSelectedReport, setEditReport, setDrawerOpened, showOnMap, searchParams, navigate]);
 
     return (
         <>

--- a/src/features/reports/table/TableReport.tsx
+++ b/src/features/reports/table/TableReport.tsx
@@ -57,8 +57,6 @@ const TableReport = () => {
         currentPage,
         currentFilters,
         setLimitPerPage,
-        selectedLine,
-        setSelectedLine,
         sortBy,
         setSortBy,
         setCurrentPage,
@@ -66,7 +64,10 @@ const TableReport = () => {
         reportTableWidth,
         toggleSortByDateCreation,
         syncUrlFromState,
+        getSelectedLineCount,
     } = useReportStore();
+
+    const selectedLineCount = getSelectedLineCount();
 
     const { replyReportModal, deleteReportModal } = useModalStore();
     const filters = useMemo(
@@ -107,7 +108,7 @@ const TableReport = () => {
 
     useEffect(() => {
         if (isErrorReport) {
-            addAlertMessage(StatusMessage.error, "Erreur lors du chargement des signalements.", 3000);
+            addAlertMessage(StatusMessage.error, t("error"), 3000);
         }
     }, [isErrorReport, addAlertMessage]);
 
@@ -167,20 +168,12 @@ const TableReport = () => {
         return CreateTableData(exportedData.data, isChecked, onCheckChange, onShowReportOnMap, onShowOnMap);
     }, [exportedData, isChecked, onCheckChange, onShowReportOnMap, onShowOnMap]);
 
-    const checkedLines = useMemo(() => {
-        if (!Array.isArray(selectedLines) || !isChecked) return [];
-        return selectedLines.filter((res) => !!isChecked[String(res.id)]).map((res) => res.exportData);
-    }, [selectedLines, isChecked]);
-
-    const allLinesAreAllowed = checkedLines.some((line) => STATUS_NOT_ALLOWED.includes(line.statusCode));
+    const allLinesAreAllowed = tableData.some((row) => !!isChecked[String(row.id)] && STATUS_NOT_ALLOWED.includes(row.exportData.statusCode));
 
     const downloadedTable = useMemo(() => {
-        if (checkedLines.length > 0) return checkedLines.map((exp) => exp);
-        if (Array.isArray(selectedLines)) {
-            return selectedLines.map((expData) => expData.exportData);
-        }
-        return [];
-    }, [checkedLines, selectedLines]);
+        if (!Array.isArray(selectedLines)) return [];
+        return selectedLines.map((expData) => expData.exportData);
+    }, [selectedLines]);
 
     const tableHeaderToLabel: Record<FilterHeaderKey, string> = {
         x: "X",
@@ -230,12 +223,12 @@ const TableReport = () => {
                     </div>
                     <div className="report-infos-line">
                         <div className="report-nbrSelectedLines">
-                            {selectedLine > 0 ? (
+                            {selectedLineCount > 0 ? (
                                 <>
-                                    Nombre de lignes sélectionnées: <span>{selectedLine}</span>
+                                    {t("selected_lines")} <span>{selectedLineCount}</span>
                                 </>
                             ) : (
-                                "Pas de lignes sélectionnées"
+                                t("no_lines")
                             )}
                         </div>
                         <div className="report-btns">
@@ -281,12 +274,6 @@ const TableReport = () => {
                                                 tableData.forEach((row) => {
                                                     updated[row.id] = allChecked;
                                                 });
-
-                                                if (allChecked) {
-                                                    setSelectedLine(limitPerPage);
-                                                } else {
-                                                    setSelectedLine(0);
-                                                }
                                                 setIsChecked(updated);
                                             },
                                         },

--- a/src/store/useReportStore.ts
+++ b/src/store/useReportStore.ts
@@ -30,8 +30,7 @@ interface ReportStore {
     setLimitPerPage: (limitPerPage: number) => void;
     reportTableWidth: number;
     setReportTableWidth: (reportTableWidth: number) => void;
-    selectedLine: number;
-    setSelectedLine: (selectedLine: number) => void;
+    getSelectedLineCount: () => number;
     sortOrder: "ASC" | "DESC" | undefined;
     sortBy: string;
     setSortBy: (sortBy: string) => void;
@@ -115,8 +114,7 @@ export const useReportStore = create<ReportStore>((set, get) => ({
     },
     reportTableWidth: window.innerWidth * (2 / 3),
     setReportTableWidth: (reportTableWidth: number) => set({ reportTableWidth }),
-    selectedLine: 0,
-    setSelectedLine: (selectedLine: number) => set({ selectedLine }),
+    getSelectedLineCount: () => Object.values(get().isChecked).filter(Boolean).length,
     sortOrder: undefined,
     sortBy: "",
     setSortBy: (sortBy) => set({ sortBy }),


### PR DESCRIPTION
-Fix issue #227

-Fix issue #223

<img width="1215" height="297" alt="image" src="https://github.com/user-attachments/assets/76a8a4b7-6061-4ba8-afd4-1a967438e8c8" />

-Remove Report id from URL after closing report Drawer

-And this old comment on PR #225 :
"le centrage sur un signalement ouvre par défaut le volet de création de signalement et non le volet de visu du signalement"

