### PR TITLE
Favorite position through search engine

### DIFF
--- a/src/api/geocodageData.ts
+++ b/src/api/geocodageData.ts
@@ -18,6 +18,12 @@ export interface AutocompleteResponse {
     results: CommuneResult[];
 }
 
+export interface LocationAutocompleteResult {
+    fulltext: string;
+    x: number;
+    y: number;
+}
+
 export interface ReverseGeocodeResponse {
     features: Array<{
         properties: {
@@ -73,6 +79,28 @@ export async function getCommuneAutocomplete(searchText: string): Promise<Commun
         return [];
     }
 }
+
+export async function getLocationAutocomplete(searchText: string): Promise<LocationAutocompleteResult[]> {
+    if (!searchText.trim()) {
+        return [];
+    }
+
+    try {
+        const api = await getAxiosApi();
+        const response = await api.get<AutocompleteResponse>("https://data.geopf.fr/geocodage/completion", {
+            params: {
+                text: searchText,
+                maximumResponses: 5,
+            },
+        });
+
+        return (response.data.results || []).filter((result) => typeof result.fulltext === "string" && Number.isFinite(result.x) && Number.isFinite(result.y));
+    } catch (error) {
+        console.error("Location autocomplete failed:", error);
+        return [];
+    }
+}
+
 export async function reverseGeocode(lon: number, lat: number): Promise<ReverseGeocodeResponse["features"][0] | null> {
     try {
         const api = await getAxiosApi();

--- a/src/constants/localStorage/types.ts
+++ b/src/constants/localStorage/types.ts
@@ -1,5 +1,40 @@
 import { Group } from "@/constants/savedSearches/types";
 
+export const NAMED_POSITION_UPDATED_EVENT = "named-position:updated";
+export const DEFAULT_NAMED_POSITION_ZOOM = 15;
+
+export interface NamedPosition {
+    id: string;
+    name: string;
+    coordinates: [number, number];
+    zoom: number;
+    createdAt: string;
+}
+
+export interface NamedPositionCandidate {
+    name: string;
+    coordinates: [number, number];
+    zoom: number;
+}
+
+export interface AddNamedPositionInput {
+    name: string;
+    coordinates: [number, number];
+    zoom?: number;
+}
+
+export type AddNamedPositionErrorReason = "EMPTY_NAME" | "INVALID_COORDINATES" | "DUPLICATE_NAME" | "DUPLICATE_COORDINATES";
+
+export type AddNamedPositionResult =
+    | {
+          ok: true;
+          value: NamedPosition;
+      }
+    | {
+          ok: false;
+          reason: AddNamedPositionErrorReason;
+      };
+
 export type LocalLayer = {
     name: string;
     opacity: number;
@@ -17,4 +52,5 @@ export interface LocalStorageData {
     searchRoot: Group | null;
     searchMax: number;
     searchExtent: string;
+    namedPositions: NamedPosition[];
 }

--- a/src/constants/localStorage/utils/index.ts
+++ b/src/constants/localStorage/utils/index.ts
@@ -1,0 +1,129 @@
+import { Group } from "@/constants/savedSearches/types";
+import { DEFAULT_NAMED_POSITION_ZOOM, LocalStorageData, NamedPosition } from "../types";
+
+const DUPLICATE_COORDINATE_EPSILON = 1e-6;
+
+const MIN_LONGITUDE = -180;
+const MAX_LONGITUDE = 180;
+const MIN_LATITUDE = -90;
+const MAX_LATITUDE = 90;
+
+const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+
+const normalizeName = (name: string) => name.trim().replace(/\s+/g, " ");
+
+const isCoordinateRangeValid = (longitude: number, latitude: number) => {
+    return longitude >= MIN_LONGITUDE && longitude <= MAX_LONGITUDE && latitude >= MIN_LATITUDE && latitude <= MAX_LATITUDE;
+};
+
+export const isValidNamedPositionCoordinates = (coordinates: unknown): coordinates is [number, number] => {
+    if (!Array.isArray(coordinates) || coordinates.length !== 2) {
+        return false;
+    }
+
+    const [longitude, latitude] = coordinates;
+    if (!isFiniteNumber(longitude) || !isFiniteNumber(latitude)) {
+        return false;
+    }
+
+    return isCoordinateRangeValid(longitude, latitude);
+};
+
+const getSafeZoom = (zoom: unknown) => {
+    if (!isFiniteNumber(zoom)) {
+        return DEFAULT_NAMED_POSITION_ZOOM;
+    }
+
+    return zoom;
+};
+
+const generateNamedPositionId = () => {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+
+    return `named-position-${Date.now()}-${Math.round(Math.random() * 1000000)}`;
+};
+
+const parseNamedPosition = (value: unknown): NamedPosition | null => {
+    if (!value || typeof value !== "object") {
+        return null;
+    }
+
+    const valueRecord = value as Record<string, unknown>;
+    const rawName = typeof valueRecord.name === "string" ? valueRecord.name : "";
+    const name = normalizeName(rawName);
+
+    if (!name || !isValidNamedPositionCoordinates(valueRecord.coordinates)) {
+        return null;
+    }
+
+    const id = typeof valueRecord.id === "string" && valueRecord.id.length > 0 ? valueRecord.id : generateNamedPositionId();
+    const zoom = getSafeZoom(valueRecord.zoom);
+    const createdAt = typeof valueRecord.createdAt === "string" ? valueRecord.createdAt : new Date().toISOString();
+
+    return {
+        id,
+        name,
+        coordinates: valueRecord.coordinates,
+        zoom,
+        createdAt,
+    };
+};
+
+const sanitizeNamedPositions = (value: unknown): NamedPosition[] => {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.map(parseNamedPosition).filter((position): position is NamedPosition => position !== null);
+};
+
+export const createDefaultLocalStorageData = (): LocalStorageData => ({
+    activeLayer: "",
+    center: [],
+    layers: [],
+    zoom: 0,
+    projection: "",
+    searchRoot: null as Group | null,
+    searchMax: 20,
+    searchExtent: "",
+    namedPositions: [],
+});
+
+export const normalizeLocalStorageData = (value: unknown): LocalStorageData | null => {
+    if (!value || typeof value !== "object") {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+
+    return {
+        activeLayer: typeof record.activeLayer === "string" ? record.activeLayer : "",
+        center: Array.isArray(record.center) ? record.center.filter((item): item is number => typeof item === "number" && Number.isFinite(item)) : [],
+        layers: Array.isArray(record.layers) ? (record.layers as LocalStorageData["layers"]) : [],
+        zoom: isFiniteNumber(record.zoom) ? record.zoom : 0,
+        projection: typeof record.projection === "string" ? record.projection : "",
+        searchRoot: record.searchRoot && typeof record.searchRoot === "object" ? (record.searchRoot as Group) : null,
+        searchMax: isFiniteNumber(record.searchMax) ? record.searchMax : 20,
+        searchExtent: typeof record.searchExtent === "string" ? record.searchExtent : "",
+        namedPositions: sanitizeNamedPositions(record.namedPositions),
+    };
+};
+
+export const sanitizeNamedPositionName = normalizeName;
+
+export const areNamedPositionCoordinatesEqual = (first: [number, number], second: [number, number]) => {
+    const lonDiff = Math.abs(first[0] - second[0]);
+    const latDiff = Math.abs(first[1] - second[1]);
+
+    return lonDiff <= DUPLICATE_COORDINATE_EPSILON && latDiff <= DUPLICATE_COORDINATE_EPSILON;
+};
+
+export const createNamedPosition = (name: string, coordinates: [number, number], zoom?: number): NamedPosition => ({
+    id: generateNamedPositionId(),
+    name: sanitizeNamedPositionName(name),
+    coordinates,
+    zoom: getSafeZoom(zoom),
+    createdAt: new Date().toISOString(),
+});

--- a/src/constants/localStorage/utils/index.ts
+++ b/src/constants/localStorage/utils/index.ts
@@ -1,8 +1,6 @@
 import { Group } from "@/constants/savedSearches/types";
 import { DEFAULT_NAMED_POSITION_ZOOM, LocalStorageData, NamedPosition } from "../types";
 
-const DUPLICATE_COORDINATE_EPSILON = 1e-6;
-
 const MIN_LONGITUDE = -180;
 const MAX_LONGITUDE = 180;
 const MIN_LATITUDE = -90;
@@ -112,13 +110,6 @@ export const normalizeLocalStorageData = (value: unknown): LocalStorageData | nu
 };
 
 export const sanitizeNamedPositionName = normalizeName;
-
-export const areNamedPositionCoordinatesEqual = (first: [number, number], second: [number, number]) => {
-    const lonDiff = Math.abs(first[0] - second[0]);
-    const latDiff = Math.abs(first[1] - second[1]);
-
-    return lonDiff <= DUPLICATE_COORDINATE_EPSILON && latDiff <= DUPLICATE_COORDINATE_EPSILON;
-};
 
 export const createNamedPosition = (name: string, coordinates: [number, number], zoom?: number): NamedPosition => ({
     id: generateNamedPositionId(),

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -18,3 +18,4 @@
 @import url("./search-by-property-modal.css");
 @import url("./map-tooltip.css");
 @import url("./export-map-modal.css");
+@import url("./search-favorites.css");

--- a/src/css/map-tooltip.css
+++ b/src/css/map-tooltip.css
@@ -10,7 +10,7 @@
     max-width: 20rem;
     min-width: 10rem;
     width: max-content;
-    box-shadow: 0 -0.1rem 0.5rem var(--overlays-shadow);
+    box-shadow: 0 -0.1rem 0.5rem;
 }
 
 .map-hover-tooltip-title {

--- a/src/css/search-favorites.css
+++ b/src/css/search-favorites.css
@@ -122,22 +122,6 @@
     z-index: 999999;
 }
 
-.NamedPositionModalBackdrop.is-open {
-    display: flex;
-}
-
-.NamedPositionModal {
-    width: min(80vw, 50rem);
-    height: min(90vh, 43.75rem);
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    background: var(--background-default-grey);
-    border-radius: 0.5rem;
-    padding: 1rem;
-    box-shadow: 0 0.375rem 1.125rem var(--overlay-shadwow);
-}
-
 .NamedPositionModalTitle {
     margin: 0 0 1rem;
 }

--- a/src/css/search-favorites.css
+++ b/src/css/search-favorites.css
@@ -1,0 +1,256 @@
+[id^="GPsearchEngine-Advanced"] .GPNamedPositionOpenButton {
+    width: 100%;
+    justify-content: flex-start;
+    margin: 0 0 0.75rem;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionSection {
+    margin: 0;
+    padding: 0;
+    border-top: 0.0625rem solid var(--border-default-grey);
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionTitle {
+    margin: 0;
+    padding: 0.75rem 0.75rem 0.625rem;
+    font-size: 0.94rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--text-default-title);
+    background: transparent;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionList {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    max-height: 17.5rem;
+    overflow-y: auto;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionItem {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    border-top: 0.06rem solid var(--border-default-grey);
+    padding: 0;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionItem:hover {
+    background: transparent;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionSelect {
+    flex: 1;
+    border: 0;
+    border-radius: 0;
+    background-color: transparent;
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    font-weight: 400;
+    font-size: 0.94rem;
+    line-height: 1.4;
+    color: var(--text-action-high-blue-france);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionSelect:hover,
+[id^="GPsearchEngine"] .GPNamedPositionSelect:focus-visible {
+    background: var(--background-alt-grey);
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionSelect:focus-visible {
+    outline: 0.125rem solid var(--border-action-high-blue-france);
+    outline-offset: -0.125rem;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionDelete {
+    flex: 0 0 auto;
+    min-height: 100%;
+    min-width: 2.5rem;
+    padding: 0.6rem 0.75rem;
+    background: transparent;
+    border-radius: 0;
+    border-left: 0.06rem solid var(--border-default-grey);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease;
+    color: var(--text-action-high-blue-france);
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionDelete:hover {
+    background: var(--background-alt-grey);
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionDelete:focus-visible {
+    outline: 0.125rem solid var(--border-action-high-blue-france);
+    outline-offset: -0.125rem;
+}
+
+[id^="GPsearchEngine"] .GPNamedPositionEmpty {
+    margin: 0;
+    padding: 0.75rem;
+    border: 0;
+    border-top: 0.0625rem solid var(--border-default-grey);
+    border-radius: 0;
+    color: var(--text-mention-grey);
+    font-size: 0.87rem;
+    text-align: center;
+    background: transparent;
+}
+
+.NamedPositionModalBackdrop {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: var(--overlay-shadwow);
+    z-index: 999999;
+}
+
+.NamedPositionModalBackdrop.is-open {
+    display: flex;
+}
+
+.NamedPositionModal {
+    width: min(80vw, 50rem);
+    height: min(90vh, 43.75rem);
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    background: var(--background-default-grey);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    box-shadow: 0 0.375rem 1.125rem var(--overlay-shadwow);
+}
+
+.NamedPositionModalTitle {
+    margin: 0 0 1rem;
+}
+
+.NamedPositionModalForm {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex: 1;
+    overflow-y: auto;
+}
+
+.NamedPositionSourceFieldset {
+    margin: 0;
+}
+
+.NamedPositionSourceFieldset .fr-fieldset__legend {
+    margin-bottom: 0.5rem;
+}
+
+.NamedPositionSourceOptions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.NamedPositionSourceOptions .fr-radio-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    margin-bottom: 0;
+}
+
+.NamedPositionSourceOptions .fr-label {
+    white-space: normal;
+}
+
+.NamedPositionSourceContent {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.NamedPositionSelectedResultHint {
+    margin: 0;
+    color: var(--text-mention-grey);
+}
+
+.NamedPositionAutocompleteLoading {
+    margin: 0;
+    color: var(--text-mention-grey);
+}
+
+.NamedPositionAutocompleteList {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border: 0.0625rem solid var(--border-default-grey);
+    border-radius: 0.25rem;
+    max-height: 12rem;
+    overflow-y: auto;
+}
+
+.NamedPositionAutocompleteItem + .NamedPositionAutocompleteItem {
+    border-top: 0.0625rem solid var(--border-default-grey);
+}
+
+.NamedPositionAutocompleteItem > button {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+}
+
+.NamedPositionAutocompleteItem > button:hover,
+.NamedPositionAutocompleteItem > button:focus-visible {
+    background: var(--background-alt-grey);
+}
+
+.NamedPositionManualCoordinates {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.NamedPositionModalActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.NamedPositionModalError {
+    margin: 0;
+    color: var(--text-default-error);
+}
+
+@media (max-width: 36rem) {
+    .NamedPositionModal {
+        width: min(95vw, 37.5rem);
+        height: min(95vh, 40.5rem);
+    }
+
+    .NamedPositionManualCoordinates {
+        grid-template-columns: 1fr;
+    }
+
+    .NamedPositionModalActions {
+        flex-direction: column-reverse;
+        align-items: stretch;
+    }
+}

--- a/src/features/navigation/ViewHandler.tsx
+++ b/src/features/navigation/ViewHandler.tsx
@@ -58,6 +58,7 @@ const ViewHandler: React.FC = () => {
             searchExtent: "",
             searchMax: 20,
             searchRoot: null,
+            namedPositions: localStorageData?.namedPositions ?? [],
         };
 
         if (!isEqual(newLocalStorageData, localStorageData)) {

--- a/src/features/navigation/controls/GuichetSearchEngineControl.ts
+++ b/src/features/navigation/controls/GuichetSearchEngineControl.ts
@@ -65,7 +65,6 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
     private cleanups: Array<() => void> = [];
     private favoritesSection: HTMLDivElement | null = null;
     private favoritesList: HTMLUListElement | null = null;
-    private favoritesEmpty: HTMLParagraphElement | null = null;
     private lastSaveCandidate: NamedPositionCandidate | null = null;
 
     constructor(options: NamedPositionSearchEngineOptions) {
@@ -117,8 +116,44 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
             window.removeEventListener(NAMED_POSITION_UPDATED_EVENT, onNamedPositionUpdate as EventListener);
         });
 
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== "Escape") {
+                return;
+            }
+
+            this.closeSearchPanels();
+        };
+
+        document.addEventListener("keydown", onKeyDown);
+
+        this.cleanups.push(() => {
+            document.removeEventListener("keydown", onKeyDown);
+        });
+
         this.renderFavoritesSection("history");
         this.isNamedPositionUiReady = true;
+    }
+
+    private closeSearchPanels() {
+        if (this.advancedBtn?.getAttribute("aria-expanded") === "true") {
+            this.listenToClick = false;
+            this.advancedBtn.setAttribute("aria-expanded", "false");
+            this.closeAllSections();
+        }
+
+        const baseSearchEngine = this.getBaseSearchEngine();
+        if (!baseSearchEngine) {
+            return;
+        }
+
+        const activeElement = document.activeElement;
+        if (activeElement instanceof HTMLElement && this.element.contains(activeElement)) {
+            activeElement.blur();
+        }
+
+        if (baseSearchEngine.input === document.activeElement) {
+            baseSearchEngine.input.blur();
+        }
     }
 
     private teardownNamedPositionUi() {
@@ -133,7 +168,6 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
         this.favoritesSection?.remove();
         this.favoritesSection = null;
         this.favoritesList = null;
-        this.favoritesEmpty = null;
 
         this.lastSaveCandidate = null;
         useMapStore.getState().setNamedPositionCandidate(null);
@@ -214,19 +248,13 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
         const list = document.createElement("ul");
         list.className = "GPNamedPositionList";
 
-        const emptyState = document.createElement("p");
-        emptyState.className = "GPNamedPositionEmpty";
-        emptyState.textContent = this.namedPositionTexts.emptyFavorites;
-
         section.appendChild(title);
         section.appendChild(list);
-        section.appendChild(emptyState);
 
         baseSearchEngine.acContainer.insertBefore(section, baseSearchEngine.autocompleteFooter);
 
         this.favoritesSection = section;
         this.favoritesList = list;
-        this.favoritesEmpty = emptyState;
     }
 
     private openModal = () => {
@@ -241,7 +269,7 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
         }
 
         const name = typeof event.title === "string" && event.title.trim().length > 0 ? event.title.trim() : this.namedPositionTexts.defaultPositionName;
-        const zoom = this.getMap()?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM;
+        const zoom = this.getMap()?.getView().getZoom() ?? DEFAULT_NAMED_POSITION_ZOOM;
 
         this.lastSaveCandidate = { name, coordinates: position, zoom };
         useMapStore.getState().setNamedPositionCandidate(this.lastSaveCandidate);
@@ -261,7 +289,7 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
         const title = typeof rawFeatureTitle === "string" && rawFeatureTitle.trim().length > 0 ? rawFeatureTitle.trim() : "";
         const inputTitle = this.getBaseSearchEngine()?.input?.value?.trim() || "";
         const name = title || inputTitle || this.namedPositionTexts.defaultPositionName;
-        const zoom = this.getMap()?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM;
+        const zoom = this.getMap()?.getView().getZoom() ?? DEFAULT_NAMED_POSITION_ZOOM;
 
         this.lastSaveCandidate = { name, coordinates: position, zoom };
         useMapStore.getState().setNamedPositionCandidate(this.lastSaveCandidate);
@@ -312,9 +340,8 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
     private renderFavoritesSection(type?: string) {
         const favoritesSection = this.favoritesSection;
         const favoritesList = this.favoritesList;
-        const favoritesEmpty = this.favoritesEmpty;
 
-        if (!favoritesSection || !favoritesList || !favoritesEmpty) {
+        if (!favoritesSection || !favoritesList) {
             return;
         }
 
@@ -328,7 +355,6 @@ export default class NamedPositionSearchEngineControl extends SearchEngineAdvanc
         }
 
         favoritesList.innerHTML = "";
-        favoritesEmpty.classList.add("gpf-hidden");
 
         namedPositions.forEach((namedPosition) => {
             favoritesList.appendChild(this.createFavoriteItem(namedPosition));

--- a/src/features/navigation/controls/GuichetSearchEngineControl.ts
+++ b/src/features/navigation/controls/GuichetSearchEngineControl.ts
@@ -1,0 +1,397 @@
+import SearchEngineAdvanced from "geopf-extensions-openlayers/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js";
+import OlFeature from "ol/Feature";
+import Point from "ol/geom/Point";
+import type Map from "ol/Map";
+import type Geometry from "ol/geom/Geometry";
+import { getCenter } from "ol/extent";
+import { transform } from "ol/proj";
+import { NAMED_POSITION_UPDATED_EVENT, NamedPosition, NamedPositionCandidate, DEFAULT_NAMED_POSITION_ZOOM } from "@/constants/localStorage/types";
+import { isValidNamedPositionCoordinates } from "@/constants/localStorage/utils";
+import { useCommunityStore, useLocalStorageStore, useModalStore } from "@/store";
+import { useMapStore } from "@/store/useMapStore";
+
+interface SearchEngineBaseLike {
+    _updateList: (tab?: unknown[], type?: string) => void;
+    acContainer: HTMLDivElement;
+    autocompleteFooter: HTMLDivElement;
+    input: HTMLInputElement;
+}
+
+interface ObservableLike {
+    on: (type: string, listener: (event: unknown) => void) => void;
+    un: (type: string, listener: (event: unknown) => void) => void;
+}
+
+interface SearchSelectionEvent {
+    item?: unknown;
+    title?: string;
+}
+
+interface SearchResultEvent {
+    result?: OlFeature<Geometry>;
+}
+
+export interface NamedPositionTexts {
+    openModalButton: string;
+    favoritesTitle: string;
+    emptyFavorites: string;
+    removeFavorite: string;
+    modalTitle: string;
+    positionNameLabel: string;
+    sourceLabel: string;
+    sourceSelectedResult: string;
+    sourceMapCenter: string;
+    sourceManualCoordinates: string;
+    longitudeLabel: string;
+    latitudeLabel: string;
+    saveButton: string;
+    cancelButton: string;
+    defaultPositionName: string;
+    selectedResultUnavailable: string;
+    errorEmptyName: string;
+    errorInvalidCoordinates: string;
+    errorDuplicateName: string;
+    errorDuplicateCoordinates: string;
+}
+
+export type NamedPositionSearchEngineOptions = ConstructorParameters<typeof SearchEngineAdvanced>[0] & {
+    namedPositionTexts: NamedPositionTexts;
+};
+
+export default class NamedPositionSearchEngineControl extends SearchEngineAdvanced {
+    private readonly namedPositionTexts: NamedPositionTexts;
+    private isNamedPositionUiReady = false;
+    private restoreUpdateList: (() => void) | null = null;
+    private cleanups: Array<() => void> = [];
+    private favoritesSection: HTMLDivElement | null = null;
+    private favoritesList: HTMLUListElement | null = null;
+    private favoritesEmpty: HTMLParagraphElement | null = null;
+    private lastSaveCandidate: NamedPositionCandidate | null = null;
+
+    constructor(options: NamedPositionSearchEngineOptions) {
+        const { namedPositionTexts, ...searchOptions } = options;
+        super(searchOptions);
+        this.namedPositionTexts = namedPositionTexts;
+    }
+
+    override setMap(map: Map | null): void {
+        if (this.isNamedPositionUiReady) {
+            this.teardownNamedPositionUi();
+        }
+
+        super.setMap(map);
+
+        if (map) {
+            this.setupNamedPositionUi();
+        }
+    }
+
+    private setupNamedPositionUi() {
+        if (this.isNamedPositionUiReady) {
+            return;
+        }
+
+        this.attachAdvancedButton();
+        this.attachFavoritesSection();
+        this.patchSearchHistoryRendering();
+
+        const observable = this.getObservable();
+        const onSearch = this.handleSearchResult as (event: unknown) => void;
+        const onSelect = this.handleSearchSelection as (event: unknown) => void;
+
+        observable.on("search", onSearch);
+        observable.on("select", onSelect);
+
+        this.cleanups.push(() => {
+            observable.un("search", onSearch);
+            observable.un("select", onSelect);
+        });
+
+        const onNamedPositionUpdate = () => {
+            this.renderFavoritesSection("history");
+        };
+
+        window.addEventListener(NAMED_POSITION_UPDATED_EVENT, onNamedPositionUpdate as EventListener);
+
+        this.cleanups.push(() => {
+            window.removeEventListener(NAMED_POSITION_UPDATED_EVENT, onNamedPositionUpdate as EventListener);
+        });
+
+        this.renderFavoritesSection("history");
+        this.isNamedPositionUiReady = true;
+    }
+
+    private teardownNamedPositionUi() {
+        this.cleanups.forEach((cleanup) => cleanup());
+        this.cleanups = [];
+
+        if (this.restoreUpdateList) {
+            this.restoreUpdateList();
+            this.restoreUpdateList = null;
+        }
+
+        this.favoritesSection?.remove();
+        this.favoritesSection = null;
+        this.favoritesList = null;
+        this.favoritesEmpty = null;
+
+        this.lastSaveCandidate = null;
+        useMapStore.getState().setNamedPositionCandidate(null);
+
+        this.isNamedPositionUiReady = false;
+    }
+
+    private getBaseSearchEngine() {
+        return this.baseSearchEngine as unknown as SearchEngineBaseLike | undefined;
+    }
+
+    private getObservable() {
+        return this as unknown as ObservableLike;
+    }
+
+    private patchSearchHistoryRendering() {
+        const baseSearchEngine = this.getBaseSearchEngine();
+        if (!baseSearchEngine || this.restoreUpdateList) {
+            return;
+        }
+
+        const originalUpdateList = baseSearchEngine._updateList.bind(baseSearchEngine);
+
+        baseSearchEngine._updateList = (tab?: unknown[], type: string = "search") => {
+            originalUpdateList(tab, type);
+            this.renderFavoritesSection(type);
+        };
+
+        this.restoreUpdateList = () => {
+            baseSearchEngine._updateList = originalUpdateList;
+        };
+    }
+
+    private attachAdvancedButton() {
+        if (!this.advancedContainer) {
+            return;
+        }
+
+        const existingButton = this.advancedContainer.querySelector(".GPNamedPositionOpenButton") as HTMLButtonElement | null;
+        if (existingButton) {
+            return;
+        }
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "GPNamedPositionOpenButton fr-btn fr-btn--sm fr-icon-star-line fr-btn--icon-left fr-btn--tertiary-no-outline";
+        button.title = this.namedPositionTexts.openModalButton;
+        button.textContent = this.namedPositionTexts.openModalButton;
+
+        const firstSection = this.advancedContainer.querySelector("section");
+        if (firstSection) {
+            this.advancedContainer.insertBefore(button, firstSection);
+        } else {
+            this.advancedContainer.appendChild(button);
+        }
+
+        button.addEventListener("click", this.openModal);
+
+        this.cleanups.push(() => {
+            button.removeEventListener("click", this.openModal);
+            button.remove();
+        });
+    }
+
+    private attachFavoritesSection() {
+        const baseSearchEngine = this.getBaseSearchEngine();
+        if (!baseSearchEngine || this.favoritesSection) {
+            return;
+        }
+
+        const section = document.createElement("div");
+        section.className = "GPNamedPositionSection gpf-hidden";
+
+        const title = document.createElement("p");
+        title.className = "GPlabelTitle GPNamedPositionTitle";
+        title.textContent = this.namedPositionTexts.favoritesTitle;
+
+        const list = document.createElement("ul");
+        list.className = "GPNamedPositionList";
+
+        const emptyState = document.createElement("p");
+        emptyState.className = "GPNamedPositionEmpty";
+        emptyState.textContent = this.namedPositionTexts.emptyFavorites;
+
+        section.appendChild(title);
+        section.appendChild(list);
+        section.appendChild(emptyState);
+
+        baseSearchEngine.acContainer.insertBefore(section, baseSearchEngine.autocompleteFooter);
+
+        this.favoritesSection = section;
+        this.favoritesList = list;
+        this.favoritesEmpty = emptyState;
+    }
+
+    private openModal = () => {
+        useMapStore.getState().setNamedPositionCandidate(this.lastSaveCandidate);
+        useModalStore.getState().namedPositionModal.open();
+    };
+
+    private handleSearchSelection = (event: SearchSelectionEvent) => {
+        const position = this.getPositionFromSuggestion(event.item);
+        if (!position) {
+            return;
+        }
+
+        const name = typeof event.title === "string" && event.title.trim().length > 0 ? event.title.trim() : this.namedPositionTexts.defaultPositionName;
+        const zoom = this.getMap()?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM;
+
+        this.lastSaveCandidate = { name, coordinates: position, zoom };
+        useMapStore.getState().setNamedPositionCandidate(this.lastSaveCandidate);
+    };
+
+    private handleSearchResult = (event: SearchResultEvent) => {
+        if (!event.result) {
+            return;
+        }
+
+        const position = this.getPositionFromFeature(event.result);
+        if (!position) {
+            return;
+        }
+
+        const rawFeatureTitle = event.result.get("infoPopup");
+        const title = typeof rawFeatureTitle === "string" && rawFeatureTitle.trim().length > 0 ? rawFeatureTitle.trim() : "";
+        const inputTitle = this.getBaseSearchEngine()?.input?.value?.trim() || "";
+        const name = title || inputTitle || this.namedPositionTexts.defaultPositionName;
+        const zoom = this.getMap()?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM;
+
+        this.lastSaveCandidate = { name, coordinates: position, zoom };
+        useMapStore.getState().setNamedPositionCandidate(this.lastSaveCandidate);
+    };
+
+    private getPositionFromSuggestion(item: unknown): [number, number] | null {
+        if (!item || typeof item !== "object") {
+            return null;
+        }
+
+        const itemRecord = item as Record<string, unknown>;
+        const position = itemRecord.position;
+        if (!position || typeof position !== "object") {
+            return null;
+        }
+
+        const positionRecord = position as Record<string, unknown>;
+        const longitude = typeof positionRecord.lon === "number" ? positionRecord.lon : positionRecord.x;
+        const latitude = typeof positionRecord.lat === "number" ? positionRecord.lat : positionRecord.y;
+
+        const coordinates: [number, number] = [Number(longitude), Number(latitude)];
+        if (!isValidNamedPositionCoordinates(coordinates)) {
+            return null;
+        }
+
+        return coordinates;
+    }
+
+    private getPositionFromFeature(feature: OlFeature<Geometry>): [number, number] | null {
+        const geometry = feature.getGeometry();
+        if (!geometry) {
+            return null;
+        }
+
+        const mapCoordinate = geometry.getType() === "Point" ? (geometry as Point).getCoordinates() : getCenter(geometry.getExtent());
+        const map = this.getMap();
+
+        const sourceProjection = map?.getView().getProjection() || "EPSG:3857";
+        const lonLatCoordinate = transform(mapCoordinate, sourceProjection, "EPSG:4326") as [number, number];
+
+        if (!isValidNamedPositionCoordinates(lonLatCoordinate)) {
+            return null;
+        }
+
+        return lonLatCoordinate;
+    }
+
+    private renderFavoritesSection(type?: string) {
+        const favoritesSection = this.favoritesSection;
+        const favoritesList = this.favoritesList;
+        const favoritesEmpty = this.favoritesEmpty;
+
+        if (!favoritesSection || !favoritesList || !favoritesEmpty) {
+            return;
+        }
+
+        const currentType = type || this.getBaseSearchEngine()?.acContainer?.dataset.type;
+        const namedPositions = useLocalStorageStore.getState().localStorageData?.namedPositions ?? [];
+        const shouldDisplayFavorites = currentType === "history" && namedPositions.length > 0;
+
+        favoritesSection.classList.toggle("gpf-hidden", !shouldDisplayFavorites);
+        if (!shouldDisplayFavorites) {
+            return;
+        }
+
+        favoritesList.innerHTML = "";
+        favoritesEmpty.classList.add("gpf-hidden");
+
+        namedPositions.forEach((namedPosition) => {
+            favoritesList.appendChild(this.createFavoriteItem(namedPosition));
+        });
+    }
+
+    private createFavoriteItem(namedPosition: NamedPosition) {
+        const item = document.createElement("li");
+        item.className = "GPNamedPositionItem";
+
+        const selectButton = document.createElement("button");
+        selectButton.type = "button";
+        selectButton.className = "GPNamedPositionSelect gpf-panel__item gpf-panel__item-searchengine fr-icon-star-line fr-icon--sm";
+        selectButton.textContent = namedPosition.name;
+        selectButton.title = namedPosition.name;
+
+        const deleteButton = document.createElement("button");
+        deleteButton.type = "button";
+        deleteButton.className = "GPNamedPositionDelete fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-delete-bin-line";
+        deleteButton.title = this.namedPositionTexts.removeFavorite;
+        deleteButton.setAttribute("aria-label", `${this.namedPositionTexts.removeFavorite}: ${namedPosition.name}`);
+
+        selectButton.addEventListener("click", () => {
+            this.focusNamedPosition(namedPosition);
+        });
+
+        deleteButton.addEventListener("click", () => {
+            const communityName = useCommunityStore.getState().community?.name;
+            if (communityName) {
+                useLocalStorageStore.getState().deleteNamedPosition(communityName, namedPosition.id);
+            }
+            this.renderFavoritesSection("history");
+        });
+
+        item.appendChild(selectButton);
+        item.appendChild(deleteButton);
+
+        return item;
+    }
+
+    private focusNamedPosition(namedPosition: NamedPosition) {
+        const map = this.getMap();
+        if (!map) {
+            return;
+        }
+
+        const mapCoordinates = transform(namedPosition.coordinates, "EPSG:4326", map.getView().getProjection()) as [number, number];
+        const point = new Point(mapCoordinates);
+        const searchEvent = this.createEvent(point, namedPosition.name);
+        this.addResultToMap(searchEvent);
+
+        const view = map.getView();
+        view.setCenter(mapCoordinates);
+        if (Number.isFinite(namedPosition.zoom)) {
+            view.setZoom(namedPosition.zoom);
+        }
+
+        this.lastSaveCandidate = {
+            name: namedPosition.name,
+            coordinates: namedPosition.coordinates,
+            zoom: namedPosition.zoom,
+        };
+
+        useMapStore.getState().setNamedPositionCandidate(this.lastSaveCandidate);
+    }
+}

--- a/src/features/navigation/controls/NamedPositionModal.tsx
+++ b/src/features/navigation/controls/NamedPositionModal.tsx
@@ -61,7 +61,7 @@ const NamedPositionModal: React.FC = () => {
         return {
             name: t("default_name"),
             coordinates,
-            zoom: map.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM,
+            zoom: map.getView().getZoom() ?? DEFAULT_NAMED_POSITION_ZOOM,
         };
     }, [map, t]);
 
@@ -268,8 +268,6 @@ const NamedPositionModal: React.FC = () => {
                 showValidationError("positionName", t("error_duplicate_name"));
                 return;
             }
-
-            showValidationError("coordinates", t("error_duplicate_coordinates"));
             return;
         }
 
@@ -324,7 +322,7 @@ const NamedPositionModal: React.FC = () => {
             setNamedPositionCandidate({
                 name: suggestion.fulltext,
                 coordinates: [suggestion.x, suggestion.y],
-                zoom: map?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM,
+                zoom: map?.getView().getZoom() ?? DEFAULT_NAMED_POSITION_ZOOM,
             });
         },
         [clearFieldError, map, positionName, setNamedPositionCandidate]

--- a/src/features/navigation/controls/NamedPositionModal.tsx
+++ b/src/features/navigation/controls/NamedPositionModal.tsx
@@ -38,6 +38,7 @@ const NamedPositionModal: React.FC = () => {
     const [isLoadingLocation, setIsLoadingLocation] = useState(false);
     const [fieldErrors, setFieldErrors] = useState<NamedPositionFieldErrors>(EMPTY_FIELD_ERRORS);
     const keepValuesOnNextOpenRef = useRef(false);
+    const clearValuesOnNextOpenRef = useRef(false);
     const locationRequestIdRef = useRef(0);
 
     const debouncedLocationQuery = useDebounce(locationQuery, 300);
@@ -86,6 +87,19 @@ const NamedPositionModal: React.FC = () => {
         setFieldErrors(EMPTY_FIELD_ERRORS);
     }, [getMapCenterCandidate, namedPositionCandidate]);
 
+    const clearForNextOpen = useCallback(() => {
+        locationRequestIdRef.current += 1;
+        setPositionName("");
+        setSource("map_center");
+        setLongitude("");
+        setLatitude("");
+        setLocationQuery("");
+        setLocationSuggestions([]);
+        setSelectedLocation(null);
+        setIsLoadingLocation(false);
+        setFieldErrors(EMPTY_FIELD_ERRORS);
+    }, []);
+
     useEffect(() => {
         if (source !== "selected_result") {
             setLocationSuggestions([]);
@@ -133,6 +147,12 @@ const NamedPositionModal: React.FC = () => {
 
     useIsModalOpen(namedPositionModal, {
         onDisclose: () => {
+            if (clearValuesOnNextOpenRef.current) {
+                clearValuesOnNextOpenRef.current = false;
+                clearForNextOpen();
+                return;
+            }
+
             if (keepValuesOnNextOpenRef.current) {
                 keepValuesOnNextOpenRef.current = false;
                 return;
@@ -142,7 +162,6 @@ const NamedPositionModal: React.FC = () => {
         },
         onConceal: () => {
             locationRequestIdRef.current += 1;
-            keepValuesOnNextOpenRef.current = false;
         },
     });
 
@@ -255,6 +274,7 @@ const NamedPositionModal: React.FC = () => {
         }
 
         setFieldErrors(EMPTY_FIELD_ERRORS);
+        clearValuesOnNextOpenRef.current = true;
 
         setNamedPositionCandidate({
             name: result.value.name,

--- a/src/features/navigation/controls/NamedPositionModal.tsx
+++ b/src/features/navigation/controls/NamedPositionModal.tsx
@@ -1,0 +1,479 @@
+import ModaleComponent from "@/components/ModaleComponent";
+import { getLocationAutocomplete, LocationAutocompleteResult } from "@/api/geocodageData";
+import { DEFAULT_NAMED_POSITION_ZOOM } from "@/constants/localStorage/types";
+import { isValidNamedPositionCoordinates } from "@/constants/localStorage/utils";
+import { StatusMessage } from "@/constants/communities/types";
+import useDebounce from "@/hooks/useDebounce";
+import { useTranslation } from "@/i18n";
+import { useCommunityStore, useLocalStorageStore, useMapStore, useModalStore } from "@/store";
+import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
+import { transform } from "ol/proj";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type SavePositionSource = "selected_result" | "map_center" | "manual_coordinates";
+
+type NamedPositionFieldErrorKey = "positionName" | "locationQuery" | "coordinates";
+
+type NamedPositionFieldErrors = Record<NamedPositionFieldErrorKey, string | null>;
+
+const EMPTY_FIELD_ERRORS: NamedPositionFieldErrors = {
+    positionName: null,
+    locationQuery: null,
+    coordinates: null,
+};
+
+const NamedPositionModal: React.FC = () => {
+    const { namedPositionModal } = useModalStore();
+    const { community, addAlertMessage } = useCommunityStore();
+    const { map, namedPositionCandidate, setNamedPositionCandidate } = useMapStore();
+    const { t } = useTranslation({ ToolsControl: {} });
+
+    const [positionName, setPositionName] = useState("");
+    const [source, setSource] = useState<SavePositionSource>("map_center");
+    const [longitude, setLongitude] = useState("");
+    const [latitude, setLatitude] = useState("");
+    const [locationQuery, setLocationQuery] = useState("");
+    const [locationSuggestions, setLocationSuggestions] = useState<LocationAutocompleteResult[]>([]);
+    const [selectedLocation, setSelectedLocation] = useState<LocationAutocompleteResult | null>(null);
+    const [isLoadingLocation, setIsLoadingLocation] = useState(false);
+    const [fieldErrors, setFieldErrors] = useState<NamedPositionFieldErrors>(EMPTY_FIELD_ERRORS);
+    const keepValuesOnNextOpenRef = useRef(false);
+    const locationRequestIdRef = useRef(0);
+
+    const debouncedLocationQuery = useDebounce(locationQuery, 300);
+
+    const getMapCenterCandidate = useCallback(() => {
+        if (!map) {
+            return null;
+        }
+
+        const center = map.getView().getCenter();
+        if (!center) {
+            return null;
+        }
+
+        const coordinates = transform(center, map.getView().getProjection(), "EPSG:4326") as [number, number];
+        if (!isValidNamedPositionCoordinates(coordinates)) {
+            return null;
+        }
+
+        return {
+            name: t("default_name"),
+            coordinates,
+            zoom: map.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM,
+        };
+    }, [map, t]);
+
+    const resetFromContext = useCallback(() => {
+        const mapCenter = getMapCenterCandidate();
+
+        setPositionName(namedPositionCandidate?.name || "");
+        setSource(namedPositionCandidate ? "selected_result" : "map_center");
+        setLongitude(mapCenter ? mapCenter.coordinates[0].toFixed(6) : "");
+        setLatitude(mapCenter ? mapCenter.coordinates[1].toFixed(6) : "");
+        setLocationQuery(namedPositionCandidate?.name || "");
+        setLocationSuggestions([]);
+        setSelectedLocation(
+            namedPositionCandidate
+                ? {
+                      fulltext: namedPositionCandidate.name,
+                      x: namedPositionCandidate.coordinates[0],
+                      y: namedPositionCandidate.coordinates[1],
+                  }
+                : null
+        );
+        setIsLoadingLocation(false);
+        setFieldErrors(EMPTY_FIELD_ERRORS);
+    }, [getMapCenterCandidate, namedPositionCandidate]);
+
+    useEffect(() => {
+        if (source !== "selected_result") {
+            setLocationSuggestions([]);
+            setIsLoadingLocation(false);
+            return;
+        }
+
+        const query = debouncedLocationQuery.trim();
+        if (query.length < 3) {
+            setLocationSuggestions([]);
+            setIsLoadingLocation(false);
+            return;
+        }
+
+        if (selectedLocation && query === selectedLocation.fulltext.trim()) {
+            setLocationSuggestions([]);
+            setIsLoadingLocation(false);
+            return;
+        }
+
+        let isCancelled = false;
+        const requestId = ++locationRequestIdRef.current;
+        setIsLoadingLocation(true);
+
+        void getLocationAutocomplete(query)
+            .then((results) => {
+                if (isCancelled || requestId !== locationRequestIdRef.current) {
+                    return;
+                }
+
+                setLocationSuggestions(results.slice(0, 5));
+            })
+            .finally(() => {
+                if (isCancelled || requestId !== locationRequestIdRef.current) {
+                    return;
+                }
+
+                setIsLoadingLocation(false);
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [debouncedLocationQuery, selectedLocation, source]);
+
+    useIsModalOpen(namedPositionModal, {
+        onDisclose: () => {
+            if (keepValuesOnNextOpenRef.current) {
+                keepValuesOnNextOpenRef.current = false;
+                return;
+            }
+
+            resetFromContext();
+        },
+        onConceal: () => {
+            locationRequestIdRef.current += 1;
+            keepValuesOnNextOpenRef.current = false;
+        },
+    });
+
+    const showValidationError = useCallback(
+        (field: NamedPositionFieldErrorKey, message: string) => {
+            setFieldErrors({ ...EMPTY_FIELD_ERRORS, [field]: message });
+            keepValuesOnNextOpenRef.current = true;
+            namedPositionModal.open();
+        },
+        [namedPositionModal]
+    );
+
+    const clearFieldError = useCallback((field: NamedPositionFieldErrorKey) => {
+        setFieldErrors((previousErrors) => {
+            if (!previousErrors[field]) {
+                return previousErrors;
+            }
+
+            return {
+                ...previousErrors,
+                [field]: null,
+            };
+        });
+    }, []);
+
+    const onChangeSource = useCallback((nextSource: SavePositionSource) => {
+        setSource(nextSource);
+        setFieldErrors(EMPTY_FIELD_ERRORS);
+    }, []);
+
+    const resolveCandidate = useCallback(() => {
+        if (source === "selected_result") {
+            if (selectedLocation) {
+                return {
+                    name: selectedLocation.fulltext,
+                    coordinates: [selectedLocation.x, selectedLocation.y] as [number, number],
+                    zoom: map?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM,
+                };
+            }
+
+            if (locationQuery.trim().length > 0) {
+                return null;
+            }
+
+            return namedPositionCandidate;
+        }
+
+        if (source === "map_center") {
+            return getMapCenterCandidate();
+        }
+
+        const lon = Number(longitude.replace(",", "."));
+        const lat = Number(latitude.replace(",", "."));
+        const coordinates: [number, number] = [lon, lat];
+
+        if (!isValidNamedPositionCoordinates(coordinates)) {
+            return null;
+        }
+
+        return {
+            name: t("default_name"),
+            coordinates,
+            zoom: map?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM,
+        };
+    }, [getMapCenterCandidate, namedPositionCandidate, latitude, locationQuery, longitude, map, selectedLocation, source, t]);
+
+    const onConfirm = useCallback(() => {
+        const candidate = resolveCandidate();
+        if (!candidate) {
+            if (source === "selected_result" && locationQuery.trim().length > 0) {
+                showValidationError("locationQuery", t("error_select_location"));
+                return;
+            }
+
+            showValidationError(
+                source === "selected_result" ? "locationQuery" : "coordinates",
+                source === "selected_result" ? t("error_selected_result_unavailable") : t("error_invalid_coordinates")
+            );
+            return;
+        }
+
+        if (!community?.name) {
+            showValidationError("positionName", t("error_empty_name"));
+            return;
+        }
+        const finalName = positionName.trim() || candidate.name.trim();
+
+        const result = useLocalStorageStore.getState().addNamedPosition(community.name, {
+            name: finalName,
+            coordinates: candidate.coordinates,
+            zoom: candidate.zoom,
+        });
+
+        if (!result.ok) {
+            if (result.reason === "EMPTY_NAME") {
+                showValidationError("positionName", t("error_empty_name"));
+                return;
+            }
+            if (result.reason === "INVALID_COORDINATES") {
+                showValidationError("coordinates", t("error_invalid_coordinates"));
+                return;
+            }
+            if (result.reason === "DUPLICATE_NAME") {
+                showValidationError("positionName", t("error_duplicate_name"));
+                return;
+            }
+
+            showValidationError("coordinates", t("error_duplicate_coordinates"));
+            return;
+        }
+
+        setFieldErrors(EMPTY_FIELD_ERRORS);
+
+        setNamedPositionCandidate({
+            name: result.value.name,
+            coordinates: result.value.coordinates,
+            zoom: result.value.zoom,
+        });
+
+        addAlertMessage(StatusMessage.success, t("save_success"));
+        namedPositionModal.close();
+    }, [
+        addAlertMessage,
+        community?.name,
+        locationQuery,
+        namedPositionModal,
+        positionName,
+        resolveCandidate,
+        setNamedPositionCandidate,
+        showValidationError,
+        source,
+        t,
+    ]);
+
+    const onChangeLocationQuery = useCallback(
+        (value: string) => {
+            setLocationQuery(value);
+            clearFieldError("locationQuery");
+
+            if (selectedLocation && value !== selectedLocation.fulltext) {
+                setSelectedLocation(null);
+            }
+        },
+        [clearFieldError, selectedLocation]
+    );
+
+    const onSelectLocationSuggestion = useCallback(
+        (suggestion: LocationAutocompleteResult) => {
+            setSelectedLocation(suggestion);
+            setLocationQuery(suggestion.fulltext);
+            setLocationSuggestions([]);
+            setIsLoadingLocation(false);
+            clearFieldError("locationQuery");
+
+            if (!positionName.trim()) {
+                setPositionName(suggestion.fulltext);
+            }
+
+            setNamedPositionCandidate({
+                name: suggestion.fulltext,
+                coordinates: [suggestion.x, suggestion.y],
+                zoom: map?.getView().getZoom() || DEFAULT_NAMED_POSITION_ZOOM,
+            });
+        },
+        [clearFieldError, map, positionName, setNamedPositionCandidate]
+    );
+
+    const onClose = useCallback(() => {
+        namedPositionModal.close();
+    }, [namedPositionModal]);
+
+    return (
+        <ModaleComponent
+            modal={namedPositionModal}
+            title={t("modal_title")}
+            onConfirm={onConfirm}
+            onClose={onClose}
+            confirmText={t("save_button")}
+            cancelText={t("cancel_button")}
+        >
+            <div className="NamedPositionModalForm">
+                <p className="fr-hint-text">{t("modal_helper_text")}</p>
+
+                <div className={`fr-input-group${fieldErrors.positionName ? " fr-input-group--error" : ""}`}>
+                    <label className="fr-label" htmlFor="named-position-name-input">
+                        {t("name_label")}
+                    </label>
+                    <input
+                        id="named-position-name-input"
+                        type="text"
+                        className="fr-input"
+                        autoComplete="off"
+                        maxLength={120}
+                        value={positionName}
+                        onChange={(event) => {
+                            setPositionName(event.target.value);
+                            clearFieldError("positionName");
+                        }}
+                    />
+                    {fieldErrors.positionName && <p className="fr-error-text">{fieldErrors.positionName}</p>}
+                </div>
+
+                <fieldset className="fr-fieldset NamedPositionSourceFieldset">
+                    <legend className="fr-fieldset__legend">{t("source_label")}</legend>
+
+                    <div className="NamedPositionSourceOptions">
+                        <div className="fr-radio-group">
+                            <input
+                                id="named-position-source-center"
+                                type="radio"
+                                name="named-position-source"
+                                value="map_center"
+                                checked={source === "map_center"}
+                                onChange={() => onChangeSource("map_center")}
+                            />
+                            <label className="fr-label" htmlFor="named-position-source-center">
+                                {t("source_map_center")}
+                            </label>
+                        </div>
+
+                        <div className="fr-radio-group">
+                            <input
+                                id="named-position-source-selected"
+                                type="radio"
+                                name="named-position-source"
+                                value="selected_result"
+                                checked={source === "selected_result"}
+                                onChange={() => onChangeSource("selected_result")}
+                            />
+                            <label className="fr-label" htmlFor="named-position-source-selected">
+                                {t("source_selected_result")}
+                            </label>
+                        </div>
+
+                        <div className="fr-radio-group">
+                            <input
+                                id="named-position-source-manual"
+                                type="radio"
+                                name="named-position-source"
+                                value="manual_coordinates"
+                                checked={source === "manual_coordinates"}
+                                onChange={() => onChangeSource("manual_coordinates")}
+                            />
+                            <label className="fr-label" htmlFor="named-position-source-manual">
+                                {t("source_manual_coordinates")}
+                            </label>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <div className="NamedPositionSourceContent">
+                    {source === "selected_result" && !namedPositionCandidate && (
+                        <p className="NamedPositionSelectedResultHint">{t("error_selected_result_unavailable")}</p>
+                    )}
+
+                    {source === "selected_result" && (
+                        <>
+                            <div className={`fr-input-group${fieldErrors.locationQuery ? " fr-input-group--error" : ""}`}>
+                                <input
+                                    id="named-position-location-input"
+                                    type="text"
+                                    className="fr-input"
+                                    autoComplete="off"
+                                    value={locationQuery}
+                                    onChange={(event) => onChangeLocationQuery(event.target.value)}
+                                    placeholder={t("location_search_placeholder")}
+                                />
+                                {fieldErrors.locationQuery && <p className="fr-error-text">{fieldErrors.locationQuery}</p>}
+                            </div>
+
+                            {isLoadingLocation && <p className="NamedPositionAutocompleteLoading">{t("location_suggestions_loading")}</p>}
+
+                            {locationSuggestions.length > 0 && (
+                                <ul className="NamedPositionAutocompleteList" role="listbox">
+                                    {locationSuggestions.map((suggestion) => {
+                                        const key = `${suggestion.fulltext}-${suggestion.x}-${suggestion.y}`;
+                                        return (
+                                            <li key={key} className="NamedPositionAutocompleteItem" role="option">
+                                                <button type="button" onClick={() => onSelectLocationSuggestion(suggestion)}>
+                                                    {suggestion.fulltext}
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            )}
+                        </>
+                    )}
+
+                    <div className={`NamedPositionManualCoordinates ${source === "manual_coordinates" ? "" : "gpf-hidden"}`}>
+                        <div className={`fr-input-group${fieldErrors.coordinates ? " fr-input-group--error" : ""}`}>
+                            <label className="fr-label" htmlFor="named-position-lat-input">
+                                {t("latitude_label")}
+                            </label>
+                            <input
+                                id="named-position-lat-input"
+                                type="text"
+                                className="fr-input"
+                                inputMode="decimal"
+                                autoComplete="off"
+                                value={latitude}
+                                onChange={(event) => {
+                                    setLatitude(event.target.value);
+                                    clearFieldError("coordinates");
+                                }}
+                            />
+                        </div>
+
+                        <div className={`fr-input-group${fieldErrors.coordinates ? " fr-input-group--error" : ""}`}>
+                            <label className="fr-label" htmlFor="named-position-lon-input">
+                                {t("longitude_label")}
+                            </label>
+                            <input
+                                id="named-position-lon-input"
+                                type="text"
+                                className="fr-input"
+                                inputMode="decimal"
+                                autoComplete="off"
+                                value={longitude}
+                                onChange={(event) => {
+                                    setLongitude(event.target.value);
+                                    clearFieldError("coordinates");
+                                }}
+                            />
+                            {fieldErrors.coordinates && <p className="fr-error-text">{fieldErrors.coordinates}</p>}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </ModaleComponent>
+    );
+};
+
+export default NamedPositionModal;

--- a/src/features/navigation/controls/ToolsControl.tsx
+++ b/src/features/navigation/controls/ToolsControl.tsx
@@ -1,4 +1,3 @@
-import SearchEngineAdvanced from "geopf-extensions-openlayers/src/packages/Controls/SearchEngine/SearchEngineAdvanced.js";
 import CoordinateAdvancedSearch from "geopf-extensions-openlayers/src/packages/Controls/SearchEngine/CoordinateAdvancedSearch.js";
 import GeoportalOverviewMap from "geopf-extensions-openlayers/src/packages/Controls/OverviewMap/GeoportalOverviewMap.js";
 import { Control } from "ol/control";
@@ -12,6 +11,7 @@ import { translateSearchEngineControl, translateZoomControl } from "@/constants/
 import { useCommunityStore, useMapStore } from "@/store";
 import { CommunityLayerFunctionalityType } from "@/constants/communities/types";
 import useGetOverviewMapLayer from "@/hooks/navigation/layers/useGetOverviewMapLayer";
+import NamedPositionSearchEngineControl from "@/features/navigation/controls/GuichetSearchEngineControl";
 import AbstractAdvancedSearch from "geopf-extensions-openlayers/src/packages/Controls/SearchEngine/AbstractAdvancedSearch";
 
 const useToolsControl = (): Control[] => {
@@ -41,6 +41,29 @@ const useToolsControl = (): Control[] => {
 
     const hasMiniMap = community?.functionalities?.includes(CommunityLayerFunctionalityType.OVERVIEW);
 
+    const namedPositionTexts = {
+        openModalButton: t("open_button"),
+        favoritesTitle: t("favorites_title"),
+        emptyFavorites: t("empty_favorites"),
+        removeFavorite: t("remove_favorite"),
+        modalTitle: t("modal_title"),
+        positionNameLabel: t("name_label"),
+        sourceLabel: t("source_label"),
+        sourceSelectedResult: t("source_selected_result"),
+        sourceMapCenter: t("source_map_center"),
+        sourceManualCoordinates: t("source_manual_coordinates"),
+        longitudeLabel: t("longitude_label"),
+        latitudeLabel: t("latitude_label"),
+        saveButton: t("save_button"),
+        cancelButton: t("cancel_button"),
+        defaultPositionName: t("default_name"),
+        selectedResultUnavailable: t("error_selected_result_unavailable"),
+        errorEmptyName: t("error_empty_name"),
+        errorInvalidCoordinates: t("error_invalid_coordinates"),
+        errorDuplicateName: t("error_duplicate_name"),
+        errorDuplicateCoordinates: t("error_duplicate_coordinates"),
+    };
+
     // const hasLocateControl = community?.functionalities?.includes(CommunityLayerFunctionalityType.LOCATE_CONTROL);
 
     useEffect(() => {
@@ -67,7 +90,7 @@ const useToolsControl = (): Control[] => {
     }, [hasMiniMap, overviewMapLayer, map]);
 
     return [
-        new SearchEngineAdvanced({
+        new NamedPositionSearchEngineControl({
             displayButtonAdvancedSearch: advancedSearchForms.length > 0,
             apiKey: "essentiels",
             zoomTo: "auto",
@@ -77,6 +100,7 @@ const useToolsControl = (): Control[] => {
             baseSearchOptions: {
                 searchService: hasAddressSearch ? undefined : { autocomplete: false },
             },
+            namedPositionTexts,
         }),
         new GeoportalZoom({ position: "bottom-right" }),
         new MeasureLength({}),

--- a/src/features/navigation/controls/ToolsControl.tsx
+++ b/src/features/navigation/controls/ToolsControl.tsx
@@ -61,7 +61,6 @@ const useToolsControl = (): Control[] => {
         errorEmptyName: t("error_empty_name"),
         errorInvalidCoordinates: t("error_invalid_coordinates"),
         errorDuplicateName: t("error_duplicate_name"),
-        errorDuplicateCoordinates: t("error_duplicate_coordinates"),
     };
 
     // const hasLocateControl = community?.functionalities?.includes(CommunityLayerFunctionalityType.LOCATE_CONTROL);

--- a/src/features/navigation/controls/custom-controls/index.tsx
+++ b/src/features/navigation/controls/custom-controls/index.tsx
@@ -15,6 +15,7 @@ import { FEATURE_TYPE_SELECTED_PROPERTY } from "@/constants";
 import ConfirmMultipleDeselection from "./ConfirmMultipleDeselection";
 import SearchObjectsModal from "@/features/working-layer/modal/searchObjects/SearchObjectsModal";
 import ExportMapModal from "./ExportMapModal";
+import NamedPositionModal from "../NamedPositionModal";
 
 let prevClickedControl: CustomControlItem | null = null;
 
@@ -149,6 +150,7 @@ const CustomControls = () => {
             <ConfirmMultipleDeselection onConfirm={() => onConfirm(prevClickedControl!)} />
             <SearchObjectsModal />
             <ExportMapModal />
+            <NamedPositionModal />
         </>
     );
 };

--- a/src/features/navigation/controls/locale/ToolsControl.locale.tsx
+++ b/src/features/navigation/controls/locale/ToolsControl.locale.tsx
@@ -9,7 +9,7 @@ export const ToolsControlFrTranslations: Translations<"fr">["ToolsControl"] = {
     empty_favorites: "Aucune position favorite enregistrée.",
     remove_favorite: "Retirer des favoris",
     modal_title: "Ajouter une position favorite",
-    modal_helper_text: "Retrouvez vos positions préférées en cliqaunt dans la barre de recherche centrale de la carte",
+    modal_helper_text: "Retrouvez vos positions préférées en cliquant dans la barre de recherche centrale de la carte",
     name_label: "Nom",
     source_label: "Choisissez une source",
     source_selected_result: "Effectuez une recherche",
@@ -20,14 +20,13 @@ export const ToolsControlFrTranslations: Translations<"fr">["ToolsControl"] = {
     save_button: "Enregistrer la position",
     cancel_button: "Annuler",
     default_name: "Position favorite",
-    error_selected_result_unavailable: "Aucun resultat de recherche selectionne.",
+    error_selected_result_unavailable: "Aucun résultat de recherche selectionné.",
     location_search_placeholder: "Rechercher un lieu, une adresse, ...",
     location_suggestions_loading: "Chargement des suggestions...",
     error_select_location: "Selectionnez une suggestion de lieu.",
     error_empty_name: "Le nom de la position est obligatoire.",
     error_invalid_coordinates: "Les coordonnees saisies sont invalides.",
     error_duplicate_name: "Une position avec ce nom existe deja.",
-    error_duplicate_coordinates: "Une position avec ces coordonnees existe deja.",
     save_success: "Position favorite enregistree.",
 };
 
@@ -39,7 +38,7 @@ export const ToolsControlEnTranslations: Translations<"en">["ToolsControl"] = {
     empty_favorites: "No favourite position yet.",
     remove_favorite: "Remove from favourites",
     modal_title: "Add favourite position",
-    modal_helper_text: "Find your favorite positions again by clicking in the central search bar of the map",
+    modal_helper_text: "Find your favourite positions again by clicking in the central search bar of the map",
     name_label: "Name",
     source_label: "Choose a source",
     source_selected_result: "Search a place",
@@ -57,7 +56,6 @@ export const ToolsControlEnTranslations: Translations<"en">["ToolsControl"] = {
     error_empty_name: "Position name is required.",
     error_invalid_coordinates: "The coordinates are invalid.",
     error_duplicate_name: "A position with this name already exists.",
-    error_duplicate_coordinates: "A position with these coordinates already exists.",
     save_success: "Starred position saved.",
 };
 
@@ -87,7 +85,6 @@ const { i18n } = declareComponentKeys<
     | "error_empty_name"
     | "error_invalid_coordinates"
     | "error_duplicate_name"
-    | "error_duplicate_coordinates"
     | "save_success"
 >()("ToolsControl");
 export type I18n = typeof i18n;

--- a/src/features/navigation/controls/locale/ToolsControl.locale.tsx
+++ b/src/features/navigation/controls/locale/ToolsControl.locale.tsx
@@ -25,9 +25,9 @@ export const ToolsControlFrTranslations: Translations<"fr">["ToolsControl"] = {
     location_suggestions_loading: "Chargement des suggestions...",
     error_select_location: "Selectionnez une suggestion de lieu.",
     error_empty_name: "Le nom de la position est obligatoire.",
-    error_invalid_coordinates: "Les coordonnees saisies sont invalides.",
+    error_invalid_coordinates: "Les coordonnées saisies sont invalides.",
     error_duplicate_name: "Une position avec ce nom existe deja.",
-    save_success: "Position favorite enregistree.",
+    save_success: "Position favorite enregistrée.",
 };
 
 export const ToolsControlEnTranslations: Translations<"en">["ToolsControl"] = {

--- a/src/features/navigation/controls/locale/ToolsControl.locale.tsx
+++ b/src/features/navigation/controls/locale/ToolsControl.locale.tsx
@@ -4,12 +4,90 @@ import { declareComponentKeys } from "i18nifty";
 export const ToolsControlFrTranslations: Translations<"fr">["ToolsControl"] = {
     search_engine_placeholder: "Rechercher un lieu, ...", //une Adresse
     minimap: "Mini-carte",
+    open_button: "Ajouter une position préférée",
+    favorites_title: "Vos positions préférées",
+    empty_favorites: "Aucune position favorite enregistrée.",
+    remove_favorite: "Retirer des favoris",
+    modal_title: "Ajouter une position favorite",
+    modal_helper_text: "Retrouvez vos positions préférées en cliqaunt dans la barre de recherche centrale de la carte",
+    name_label: "Nom",
+    source_label: "Choisissez une source",
+    source_selected_result: "Effectuez une recherche",
+    source_map_center: "Centre actuel de la carte",
+    source_manual_coordinates: "Coordonnées manuelles",
+    longitude_label: "Longitude",
+    latitude_label: "Latitude",
+    save_button: "Enregistrer la position",
+    cancel_button: "Annuler",
+    default_name: "Position favorite",
+    error_selected_result_unavailable: "Aucun resultat de recherche selectionne.",
+    location_search_placeholder: "Rechercher un lieu, une adresse, ...",
+    location_suggestions_loading: "Chargement des suggestions...",
+    error_select_location: "Selectionnez une suggestion de lieu.",
+    error_empty_name: "Le nom de la position est obligatoire.",
+    error_invalid_coordinates: "Les coordonnees saisies sont invalides.",
+    error_duplicate_name: "Une position avec ce nom existe deja.",
+    error_duplicate_coordinates: "Une position avec ces coordonnees existe deja.",
+    save_success: "Position favorite enregistree.",
 };
 
 export const ToolsControlEnTranslations: Translations<"en">["ToolsControl"] = {
     search_engine_placeholder: "Search a place, ...",
     minimap: "Mini map",
+    open_button: "Add favourite position",
+    favorites_title: "Your favourite positions",
+    empty_favorites: "No favourite position yet.",
+    remove_favorite: "Remove from favourites",
+    modal_title: "Add favourite position",
+    modal_helper_text: "Find your favorite positions again by clicking in the central search bar of the map",
+    name_label: "Name",
+    source_label: "Choose a source",
+    source_selected_result: "Search a place",
+    source_map_center: "Current map center",
+    source_manual_coordinates: "Manual coordinates",
+    longitude_label: "Longitude",
+    latitude_label: "Latitude",
+    save_button: "Save position",
+    cancel_button: "Cancel",
+    default_name: "Starred position",
+    error_selected_result_unavailable: "No search result selected.",
+    location_search_placeholder: "Search a location, an address, ...",
+    location_suggestions_loading: "Loading suggestions...",
+    error_select_location: "Select a location suggestion.",
+    error_empty_name: "Position name is required.",
+    error_invalid_coordinates: "The coordinates are invalid.",
+    error_duplicate_name: "A position with this name already exists.",
+    error_duplicate_coordinates: "A position with these coordinates already exists.",
+    save_success: "Starred position saved.",
 };
 
-const { i18n } = declareComponentKeys<"search_engine_placeholder" | "minimap">()("ToolsControl");
+const { i18n } = declareComponentKeys<
+    | "search_engine_placeholder"
+    | "minimap"
+    | "open_button"
+    | "favorites_title"
+    | "empty_favorites"
+    | "remove_favorite"
+    | "modal_title"
+    | "modal_helper_text"
+    | "name_label"
+    | "source_label"
+    | "source_selected_result"
+    | "source_map_center"
+    | "source_manual_coordinates"
+    | "longitude_label"
+    | "latitude_label"
+    | "save_button"
+    | "cancel_button"
+    | "default_name"
+    | "error_selected_result_unavailable"
+    | "location_search_placeholder"
+    | "location_suggestions_loading"
+    | "error_select_location"
+    | "error_empty_name"
+    | "error_invalid_coordinates"
+    | "error_duplicate_name"
+    | "error_duplicate_coordinates"
+    | "save_success"
+>()("ToolsControl");
 export type I18n = typeof i18n;

--- a/src/features/working-layer/modal/searchObjects/SearchObjectsModal.tsx
+++ b/src/features/working-layer/modal/searchObjects/SearchObjectsModal.tsx
@@ -164,6 +164,7 @@ const SearchObjectsModal = () => {
             layers: localStorageData?.layers ?? [],
             zoom: localStorageData?.zoom ?? 1,
             projection: localStorageData?.projection ?? "",
+            namedPositions: localStorageData?.namedPositions ?? [],
         };
         setLocalStorage(community.name, newLocalStoageData);
     }, [searchModal, performSearch, community, localStorageData, root, maxNumber, selectedExtent, setLocalStorage]);

--- a/src/store/useLocalStorageStore.ts
+++ b/src/store/useLocalStorageStore.ts
@@ -6,13 +6,7 @@ import {
     NamedPosition,
     NAMED_POSITION_UPDATED_EVENT,
 } from "@/constants/localStorage/types";
-import {
-    areNamedPositionCoordinatesEqual,
-    createDefaultLocalStorageData,
-    createNamedPosition,
-    normalizeLocalStorageData,
-    sanitizeNamedPositionName,
-} from "@/constants/localStorage/utils";
+import { createDefaultLocalStorageData, createNamedPosition, normalizeLocalStorageData, sanitizeNamedPositionName } from "@/constants/localStorage/utils";
 import { create } from "zustand";
 
 interface LocalStorageStore {
@@ -68,11 +62,6 @@ const validateNamedPositionInput = (data: LocalStorageData, input: AddNamedPosit
     const hasDuplicateName = data.namedPositions.some((position) => sanitizeNamedPositionName(position.name).toLowerCase() === name.toLowerCase());
     if (hasDuplicateName) {
         return { ok: false, reason: "DUPLICATE_NAME" };
-    }
-
-    const hasDuplicateCoordinates = data.namedPositions.some((position) => areNamedPositionCoordinatesEqual(position.coordinates, input.coordinates));
-    if (hasDuplicateCoordinates) {
-        return { ok: false, reason: "DUPLICATE_COORDINATES" };
     }
 
     return {

--- a/src/store/useLocalStorageStore.ts
+++ b/src/store/useLocalStorageStore.ts
@@ -1,22 +1,136 @@
-import { LocalStorageData } from "@/constants/localStorage/types";
+import {
+    AddNamedPositionInput,
+    AddNamedPositionResult,
+    DEFAULT_NAMED_POSITION_ZOOM,
+    LocalStorageData,
+    NamedPosition,
+    NAMED_POSITION_UPDATED_EVENT,
+} from "@/constants/localStorage/types";
+import {
+    areNamedPositionCoordinatesEqual,
+    createDefaultLocalStorageData,
+    createNamedPosition,
+    normalizeLocalStorageData,
+    sanitizeNamedPositionName,
+} from "@/constants/localStorage/utils";
 import { create } from "zustand";
 
 interface LocalStorageStore {
     localStorageData: LocalStorageData | null;
     initLocalStorage: (communityName: string) => void;
     setLocalStorage: (communityName: string, data: LocalStorageData) => void;
+    addNamedPosition: (communityName: string, input: AddNamedPositionInput) => AddNamedPositionResult;
+    deleteNamedPosition: (communityName: string, id: string) => NamedPosition[];
 }
+
+const getPersistedLocalStorageData = (communityName: string) => {
+    const rawData = window.localStorage.getItem(communityName);
+    if (!rawData) {
+        return null;
+    }
+    try {
+        return normalizeLocalStorageData(JSON.parse(rawData));
+    } catch {
+        return null;
+    }
+};
+
+const saveLocalStorageData = (communityName: string, data: LocalStorageData) => {
+    window.localStorage.setItem(communityName, JSON.stringify(data));
+};
+
+const buildLocalStorageData = (data: LocalStorageData): LocalStorageData => ({
+    ...createDefaultLocalStorageData(),
+    ...data,
+    namedPositions: data.namedPositions ?? [],
+});
+
+const hasValidCoordinates = (coordinates: [number, number]) => {
+    const [longitude, latitude] = coordinates;
+    if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) {
+        return false;
+    }
+
+    return longitude >= -180 && longitude <= 180 && latitude >= -90 && latitude <= 90;
+};
+
+const validateNamedPositionInput = (data: LocalStorageData, input: AddNamedPositionInput): AddNamedPositionResult => {
+    const name = sanitizeNamedPositionName(input.name);
+
+    if (!name) {
+        return { ok: false, reason: "EMPTY_NAME" };
+    }
+
+    if (!Array.isArray(input.coordinates) || input.coordinates.length !== 2 || !hasValidCoordinates(input.coordinates)) {
+        return { ok: false, reason: "INVALID_COORDINATES" };
+    }
+
+    const hasDuplicateName = data.namedPositions.some((position) => sanitizeNamedPositionName(position.name).toLowerCase() === name.toLowerCase());
+    if (hasDuplicateName) {
+        return { ok: false, reason: "DUPLICATE_NAME" };
+    }
+
+    const hasDuplicateCoordinates = data.namedPositions.some((position) => areNamedPositionCoordinatesEqual(position.coordinates, input.coordinates));
+    if (hasDuplicateCoordinates) {
+        return { ok: false, reason: "DUPLICATE_COORDINATES" };
+    }
+
+    return {
+        ok: true,
+        value: createNamedPosition(name, input.coordinates, input.zoom ?? DEFAULT_NAMED_POSITION_ZOOM),
+    };
+};
 
 export const useLocalStorageStore = create<LocalStorageStore>((set) => ({
     localStorageData: null,
     initLocalStorage: (communityName) => {
-        const newLocalStorageData = window.localStorage.getItem(communityName);
+        const newLocalStorageData = getPersistedLocalStorageData(communityName);
         if (newLocalStorageData) {
-            set({ localStorageData: JSON.parse(newLocalStorageData) });
+            set({ localStorageData: newLocalStorageData });
         }
     },
     setLocalStorage: (communityName, data) => {
-        window.localStorage.setItem(communityName, JSON.stringify(data));
-        set({ localStorageData: data });
+        const nextLocalStorageData = buildLocalStorageData(data);
+
+        saveLocalStorageData(communityName, nextLocalStorageData);
+        set({ localStorageData: nextLocalStorageData });
+    },
+    addNamedPosition: (communityName, input) => {
+        const currentLocalStorageData = getPersistedLocalStorageData(communityName) ?? createDefaultLocalStorageData();
+        const result = validateNamedPositionInput(currentLocalStorageData, input);
+        if (!result.ok) {
+            return result;
+        }
+
+        const namedPosition = result.value;
+        const nextLocalStorageData = {
+            ...currentLocalStorageData,
+            namedPositions: [namedPosition, ...currentLocalStorageData.namedPositions],
+        };
+
+        saveLocalStorageData(communityName, nextLocalStorageData);
+        set({ localStorageData: nextLocalStorageData });
+        window.dispatchEvent(new Event(NAMED_POSITION_UPDATED_EVENT));
+
+        return {
+            ok: true,
+            value: namedPosition,
+        };
+    },
+    deleteNamedPosition: (communityName, id) => {
+        const currentLocalStorageData = getPersistedLocalStorageData(communityName) ?? createDefaultLocalStorageData();
+        const nextNamedPositions = id
+            ? currentLocalStorageData.namedPositions.filter((position) => position.id !== id)
+            : currentLocalStorageData.namedPositions;
+        const nextLocalStorageData = {
+            ...currentLocalStorageData,
+            namedPositions: nextNamedPositions,
+        };
+
+        saveLocalStorageData(communityName, nextLocalStorageData);
+        set({ localStorageData: nextLocalStorageData });
+        window.dispatchEvent(new Event(NAMED_POSITION_UPDATED_EVENT));
+
+        return nextNamedPositions;
     },
 }));

--- a/src/store/useMapStore.ts
+++ b/src/store/useMapStore.ts
@@ -1,4 +1,5 @@
 import { CustomControlItem, FeatureInfo, FeatureTypeSelectedStyle } from "@/constants/communities/types";
+import { NamedPositionCandidate } from "@/constants/localStorage/types";
 import { ClickedTool } from "@/constants/reports/types";
 import LayerSwitcher from "geopf-extensions-openlayers/src/packages/Controls/LayerSwitcher/LayerSwitcher";
 import { Feature, Map } from "ol";
@@ -16,6 +17,7 @@ interface MapStore {
     clickedControl: CustomControlItem | null;
     showMapWorkingLayerSelect: boolean;
     showCenterReportButtons: boolean;
+    namedPositionCandidate: NamedPositionCandidate | null;
     featureInfo: FeatureInfo;
     setMap: (map: Map | null, mapSwitcher: LayerSwitcher | null) => void;
     setFeatureTypeSelectedStyle: ({ layer, selectedStyle }: FeatureTypeSelectedStyle) => void;
@@ -26,6 +28,7 @@ interface MapStore {
     setClickedControl: (control: CustomControlItem | null) => void;
     setShowMapWorkingLayerSelect: (show: boolean) => void;
     setShowCenterReportButtons: (show: boolean) => void;
+    setNamedPositionCandidate: (candidate: NamedPositionCandidate | null) => void;
     setFeatureInfo: (content: string | null, title: string | null, position?: Coordinate) => void;
     clickedTool: ClickedTool;
     setClickedTool: (tool: ClickedTool) => void;
@@ -42,6 +45,7 @@ export const useMapStore = create<MapStore>((set, get) => ({
     clickedControl: null,
     showMapWorkingLayerSelect: true,
     showCenterReportButtons: false,
+    namedPositionCandidate: null,
     featureInfo: {
         content: null,
         title: null,
@@ -75,6 +79,7 @@ export const useMapStore = create<MapStore>((set, get) => ({
     setClickedControl: (control) => set({ clickedControl: control }),
     setShowMapWorkingLayerSelect: (show) => set({ showMapWorkingLayerSelect: show }),
     setShowCenterReportButtons: (show) => set({ showCenterReportButtons: show }),
+    setNamedPositionCandidate: (candidate) => set({ namedPositionCandidate: candidate }),
     setFeatureInfo: (content, title, position) =>
         set((state) => ({
             featureInfo: {

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -17,6 +17,7 @@ interface ModalState {
     confirmDeleteObjectSearchModal: ReturnType<typeof createModal>;
     confirmDeleteSavedSearchModal: ReturnType<typeof createModal>;
     exportMapModal: ReturnType<typeof createModal>;
+    namedPositionModal: ReturnType<typeof createModal>;
 }
 
 const modalConfigs = [
@@ -36,6 +37,7 @@ const modalConfigs = [
     { key: "confirmDeleteObjectSearchModal", id: "confirm-delete-object-search-modal" },
     { key: "confirmDeleteSavedSearchModal", id: "confirm-delete-saved-search-modal" },
     { key: "exportMapModal", id: "export-map-modal" },
+    { key: "namedPositionModal", id: "named-position-modal" },
 ];
 
 const modals = modalConfigs.reduce((acc, { key, id }) => {
@@ -43,4 +45,6 @@ const modals = modalConfigs.reduce((acc, { key, id }) => {
     return acc;
 }, {} as ModalState);
 
-export const useModalStore = create<ModalState>(() => modals);
+export const useModalStore = create<ModalState>(() => ({
+    ...modals,
+}));


### PR DESCRIPTION
issue #21 

Parcours utilisateur: 
- Au clique sur avancée on ajoute un nouveau bouton qui renvoie vers notre modal:

<img width="383" height="207" alt="image" src="https://github.com/user-attachments/assets/f48e67cb-6552-49ee-a35c-a147a93b3e44" />


- En parallèle, dans le champs de recherche les position sauvegardées sont affichées (via local storage, icon bin et non croix pour la suppression)

<img width="384" height="253" alt="image" src="https://github.com/user-attachments/assets/fb72d8d5-2814-4c18-99ce-792ab7e0b6c2" />


- La modal est la suivante:

<img width="568" height="500" alt="image" src="https://github.com/user-attachments/assets/dc7a6acd-0b70-4553-aa9c-0383d71c57f6" />


On a donc possibilité d'enregistrer via le centre de la carte, coordonnées ou l'autocomplétion géopf 