### PR TITLE
Snap Interaction

### DIFF
--- a/src/features/navigation/controls/custom-controls/index.tsx
+++ b/src/features/navigation/controls/custom-controls/index.tsx
@@ -10,17 +10,19 @@ import useGetInteractionsFuncs from "@/hooks/navigation/controls/useGetInteracti
 import AddOrRemoveMapControlInteraction from "./interactions/AddOrRemoveMapControlInteraction";
 import useGetInteractions from "@/hooks/navigation/controls/useGetInteractions";
 import { CustomControlItem, InteractionType } from "@/constants/communities/types";
+import { FeatureTypeFormActionMode } from "@/constants/contributions/types";
 import { FEATURE_TYPE_SELECTED_PROPERTY } from "@/constants";
 import ConfirmMultipleDeselection from "./ConfirmMultipleDeselection";
+import ConfirmMultipleObjectsActionModal from "@/features/working-layer/forms/ConfirmMultipleObjectsActionModal";
 import SearchObjectsModal from "@/features/working-layer/modal/searchObjects/SearchObjectsModal";
 import ExportMapModal from "./ExportMapModal";
 
 let prevClickedControl: CustomControlItem | null = null;
 
 const CustomControls = () => {
-    const { clickedControl, setClickedControl, setWorkingLayerDrawerOpened, setClickedMapFeature, workingLayerDrawerOpened } = useMapStore();
+    const { clickedControl, setClickedControl, setWorkingLayerDrawerOpened, setClickedMapFeature, clickedMapFeature, workingLayerDrawerOpened } = useMapStore();
     const { selectedObjects, setSelectedObjects } = useContributionStore();
-    const { confirmMultipleDeselectionModal } = useModalStore();
+    const { confirmMultipleDeselectionModal, confirmMultipleObjectsActionModal } = useModalStore();
 
     const { t } = useTranslation({ CustomControls });
 
@@ -106,8 +108,37 @@ const CustomControls = () => {
         };
     }, [clickToolButton]);
 
+    const handleConfirmDeleteMultiple = useCallback(() => {
+        confirmMultipleObjectsActionModal.close();
+        if (selectedObjects.length === 0) return;
+        interactionsFuncs.deleteSelectedObjects(selectedObjects);
+    }, [confirmMultipleObjectsActionModal, interactionsFuncs, selectedObjects]);
+
+    const isEditableTarget = useCallback((target: EventTarget | null) => {
+        return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || (target instanceof HTMLElement && target.isContentEditable);
+    }, []);
+
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Delete") {
+                console.log(clickedMapFeature, selectedObjects);
+                if (isEditableTarget(e.target)) return;
+
+                const deleteControl = controlsList.find((control) => control.interaction === InteractionType.REMOVE);
+                if (!deleteControl || deleteControl.disabled) return;
+
+                if (selectedObjects.length > 1) {
+                    confirmMultipleObjectsActionModal.open();
+                    return;
+                }
+
+                const targetFeature = selectedObjects[0] ?? null;
+                if (targetFeature) {
+                    interactionsFuncs.deleteSelectedObjects([targetFeature]);
+                }
+                return;
+            }
+
             if (e.key !== "Escape") return;
             if (workingLayerDrawerOpened) {
                 setClickedMapFeature(null);
@@ -129,7 +160,17 @@ const CustomControls = () => {
 
         document.addEventListener("keydown", handleKeyDown);
         return () => document.removeEventListener("keydown", handleKeyDown);
-    }, [clickedControl, setClickedControl, selectedObjects, workingLayerDrawerOpened, setClickedMapFeature]);
+    }, [
+        clickedControl,
+        setClickedControl,
+        selectedObjects,
+        workingLayerDrawerOpened,
+        setClickedMapFeature,
+        controlsList,
+        confirmMultipleObjectsActionModal,
+        interactionsFuncs,
+        isEditableTarget,
+    ]);
 
     return (
         <>
@@ -148,6 +189,7 @@ const CustomControls = () => {
             <AddOrRemoveSnapInteraction {...interactions} />
             <ConfirmMultipleDeselection onConfirm={() => onConfirm(prevClickedControl!)} />
             <SearchObjectsModal />
+            <ConfirmMultipleObjectsActionModal action={FeatureTypeFormActionMode.DELETE} onConfirm={handleConfirmDeleteMultiple} />
             <ExportMapModal />
         </>
     );

--- a/src/features/navigation/controls/custom-controls/interactions/AddOrRemoveSnapInteraction.tsx
+++ b/src/features/navigation/controls/custom-controls/interactions/AddOrRemoveSnapInteraction.tsx
@@ -4,12 +4,7 @@ import { useCommunityStore, useMapStore } from "@/store";
 import { useEffect, useMemo } from "react";
 
 const isEditInteraction = (interaction: InteractionType | null | undefined): boolean => {
-    return (
-        interaction === InteractionType.ADD_OBJECT ||
-        interaction === InteractionType.MODIFY ||
-        interaction === InteractionType.TRANSLATE_OBJECT ||
-        interaction === InteractionType.SPLIT_LINE
-    );
+    return interaction === InteractionType.ADD_OBJECT || interaction === InteractionType.MODIFY || interaction === InteractionType.TRANSLATE_OBJECT;
 };
 
 const SnapInteractionEffect = (props: InteractionsProps) => {

--- a/src/features/navigation/controls/custom-controls/interactions/AddOrRemoveSnapInteraction.tsx
+++ b/src/features/navigation/controls/custom-controls/interactions/AddOrRemoveSnapInteraction.tsx
@@ -1,6 +1,16 @@
+import { InteractionType } from "@/constants/communities/types";
 import { InteractionsProps } from "@/constants/contributions/types";
 import { useCommunityStore, useMapStore } from "@/store";
 import { useEffect, useMemo } from "react";
+
+const isEditInteraction = (interaction: InteractionType | null | undefined): boolean => {
+    return (
+        interaction === InteractionType.ADD_OBJECT ||
+        interaction === InteractionType.MODIFY ||
+        interaction === InteractionType.TRANSLATE_OBJECT ||
+        interaction === InteractionType.SPLIT_LINE
+    );
+};
 
 const SnapInteractionEffect = (props: InteractionsProps) => {
     const { map, clickedControl, mapWorkingLayer } = useMapStore();
@@ -11,16 +21,26 @@ const SnapInteractionEffect = (props: InteractionsProps) => {
         [communityLayers, mapWorkingLayer]
     );
 
+    const needToSnap = Boolean(currentCommunityLayer?.snapto && isEditInteraction(clickedControl?.interaction));
+
     useEffect(() => {
-        if (clickedControl && currentCommunityLayer?.snapto) {
-            map?.addInteraction(props.snapInteraction);
+        if (!map) return;
+        const interactions = map.getInteractions().getArray();
+        const hasSnap = interactions.includes(props.snapInteraction);
+
+        if (needToSnap && !hasSnap) {
+            map.addInteraction(props.snapInteraction);
         }
+        if (!needToSnap && hasSnap) {
+            map.removeInteraction(props.snapInteraction);
+        }
+
         return () => {
-            if (clickedControl && currentCommunityLayer?.snapto) {
-                map?.removeInteraction(props.snapInteraction);
+            if (map.getInteractions().getArray().includes(props.snapInteraction)) {
+                map.removeInteraction(props.snapInteraction);
             }
         };
-    }, [map, clickedControl, props, currentCommunityLayer?.snapto]);
+    }, [map, props.snapInteraction, needToSnap]);
 
     return null;
 };

--- a/src/hooks/navigation/controls/useGetInteractions.ts
+++ b/src/hooks/navigation/controls/useGetInteractions.ts
@@ -5,7 +5,7 @@ import { Draw, Modify, Select, Snap, Translate, DragBox } from "ol/interaction";
 import VectorLayer from "ol/layer/Vector";
 import WebGLVectorLayer from "ol/layer/WebGLVector";
 import VectorSource from "ol/source/Vector";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 const useGetInteractions = () => {
     const { map, mapWorkingLayer, clickedMapFeature } = useMapStore();
@@ -18,8 +18,14 @@ const useGetInteractions = () => {
 
     const currentCommunityLayer = communityLayers?.find((layer) => layer?.geoservice?.layer === mapWorkingLayer);
 
-    const snapto = currentCommunityLayer?.snapto?.split(",").map((l) => Number(l));
-    const snapToLayers = communityLayers?.filter((layer) => snapto?.includes(layer.geoservice.id)).map((layer) => layer.geoservice.layer);
+    const snapto = currentCommunityLayer?.snapto
+        ?.split(",")
+        .map((value) => Number(value.trim()))
+        .filter((value) => !Number.isNaN(value));
+    const snapCandidates = useMemo(() => communityLayers?.filter((layer) => snapto?.includes(layer.geoservice.id)) ?? [], [communityLayers, snapto]);
+    const snapTargets = useMemo(() => snapCandidates.filter((layer) => layer.type !== "geoservice"), [snapCandidates]);
+    const excludedGeoserviceTargets = useMemo(() => snapCandidates.filter((layer) => layer.type === "geoservice"), [snapCandidates]);
+    const snapToLayers = snapTargets.map((layer) => layer.geoservice.layer);
 
     const snapToFeatures = map
         ?.getAllLayers()
@@ -105,6 +111,30 @@ const useGetInteractions = () => {
         () => new Snap({ source: clickableSource, features: new Collection(snapToFeatures), intersection: true }),
         [clickableSource, snapToFeatures]
     );
+
+    const lastSnapLogRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!currentCommunityLayer?.snapto) return;
+
+        const sourceGeo = currentCommunityLayer.geoservice;
+        const sourceLabel = sourceGeo ? `${sourceGeo.title ?? sourceGeo.layer} [${sourceGeo.layer}] (id:${sourceGeo.id})` : mapWorkingLayer;
+
+        const targets = snapTargets.map((layer) => {
+            const geo = layer.geoservice;
+            return `${geo.title ?? geo.layer} [${geo.layer}] (id:${geo.id})`;
+        });
+
+        const excludedGeoservices = excludedGeoserviceTargets.map((layer) => {
+            const geo = layer.geoservice;
+            return `${geo.title ?? geo.layer} [${geo.layer}] (id:${geo.id})`;
+        });
+
+        const unknownIds = (snapto ?? []).filter((id) => !snapCandidates.some((layer) => layer.geoservice.id === id));
+        const logKey = `${sourceLabel}|${targets.join("|")}|${excludedGeoservices.join("|")}|${unknownIds.join("|")}`;
+        if (lastSnapLogRef.current === logKey) return;
+        lastSnapLogRef.current = logKey;
+    }, [currentCommunityLayer, mapWorkingLayer, snapTargets, snapCandidates, snapto, excludedGeoserviceTargets]);
 
     return {
         selectInteraction,

--- a/src/hooks/navigation/controls/useGetInteractionsFuncs.ts
+++ b/src/hooks/navigation/controls/useGetInteractionsFuncs.ts
@@ -507,6 +507,19 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
             setClickedControl,
         ]
     );
+    const deleteSelectedObjects = useCallback(
+        (features: Feature[]) => {
+            if (!currentMapWorkingSource) return;
+            features.forEach((feat) => {
+                currentMapWorkingSource.removeFeature(feat);
+                saveContribution(feat, ContributionType.DELETE, feat, mapWorkingLayer);
+                feat.unset(FEATURE_TYPE_SELECTED_PROPERTY);
+            });
+            setSelectedObjects([]);
+            setClickedMapFeature(null);
+        },
+        [currentMapWorkingSource, mapWorkingLayer, saveContribution, setSelectedObjects, setClickedMapFeature]
+    );
 
     useEffect(() => {
         return () => {
@@ -545,6 +558,7 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
         splitLineInteractionFuncPointer,
         getInteractionByType,
         handleClick,
+        deleteSelectedObjects,
     };
 };
 


### PR DESCRIPTION
We use here argument snapto of a layer: `"snapto": "80,4061",`

SnapOblig seems depreciated and is so still not used.

Snap interaction will be enable if you try to add, translate or modify an object.

Add delete key interaction

#106  