### PR TITLE
feat(logo style): read opacity rotation offset and size from api

### DIFF
--- a/src/api/featureTypesData.ts
+++ b/src/api/featureTypesData.ts
@@ -78,6 +78,12 @@ const mapStyleChildren = async (style: FeatureTypeStyleItemData) => {
                 labelXOffset: type.labelXOffset,
                 labelYOffset: type.labelYOffset,
                 labelMinZoom: type.labelMinZoom,
+                graphicHeight: type.graphicHeight,
+                graphicOpacity: type.graphicOpacity,
+                graphicWidth: type.graphicWidth,
+                graphicXOffset: type.graphicXOffset,
+                graphicYOffset: type.graphicYOffset,
+                rotation: type.rotation,
             };
         })
     );
@@ -114,6 +120,12 @@ const mapStyleItem = async (style: FeatureTypeStyleItemData) => {
                 labelYOffset: style.labelYOffset,
                 labelMinZoom: style.labelMinZoom,
                 directionField: directionField,
+                graphicHeight: style.graphicHeight,
+                graphicOpacity: style.graphicOpacity,
+                graphicWidth: style.graphicWidth,
+                graphicXOffset: style.graphicXOffset,
+                graphicYOffset: style.graphicYOffset,
+                rotation: style.rotation,
             },
             ...children,
         ],

--- a/src/constants/communities/types.ts
+++ b/src/constants/communities/types.ts
@@ -73,6 +73,12 @@ export type FeatureTypeStyleItem = {
     labelMinZoom?: number;
     condition?: SearchObjectCondition;
     directionField?: DirectionField;
+    graphicHeight?: number | null;
+    graphicOpacity?: number | null;
+    graphicWidth?: number | null;
+    graphicXOffset?: number | null;
+    graphicYOffset?: number | null;
+    rotation?: number | null;
 };
 
 export type FeatureTypeStyleItemData = FeatureTypeStyleItem & {

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -459,12 +459,19 @@ export const getStyleWebGLPoint: (isDefault: boolean) => FlatStyle | FlatStyle[]
 };
 
 export const getStyleWebGLDefault: (newStyle?: FeatureTypeStyleItem | undefined) => FlatStyle | FlatStyle[] = (newStyle) => {
-    if (newStyle?.logo)
-        return {
-            "icon-src": newStyle?.logo,
-            "icon-size": 34,
-            "icon-scale": 1,
+    if (newStyle?.logo) {
+        const iconStyle: FlatStyle = {
+            "icon-src": newStyle.logo,
+            "icon-opacity": newStyle?.graphicOpacity ?? 1,
+            "icon-rotation": newStyle?.rotation ?? 0,
+            "icon-offset": [newStyle?.graphicXOffset ?? 0, newStyle?.graphicYOffset ?? 0],
         };
+        if (newStyle?.graphicHeight && newStyle?.graphicWidth) {
+            iconStyle["icon-height"] = newStyle.graphicHeight;
+            iconStyle["icon-width"] = newStyle.graphicWidth;
+        }
+        return iconStyle;
+    }
     if (newStyle?.type) {
         const style = getRawWellKnownNames(newStyle);
         if (style) return style;

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -465,11 +465,9 @@ export const getStyleWebGLDefault: (newStyle?: FeatureTypeStyleItem | undefined)
             "icon-opacity": newStyle?.graphicOpacity ?? 1,
             "icon-rotation": newStyle?.rotation ?? 0,
             "icon-offset": [newStyle?.graphicXOffset ?? 0, newStyle?.graphicYOffset ?? 0],
+            "icon-height": newStyle?.graphicHeight ?? 25,
+            "icon-width": newStyle?.graphicWidth ?? 25,
         };
-        if (newStyle?.graphicHeight && newStyle?.graphicWidth) {
-            iconStyle["icon-height"] = newStyle.graphicHeight;
-            iconStyle["icon-width"] = newStyle.graphicWidth;
-        }
         return iconStyle;
     }
     if (newStyle?.type) {


### PR DESCRIPTION
On utilise maintenant ces paramètres pour définir les icônes définies pour des ponctuels WFS:

-     graphicHeight
-     graphicOpacity
-     graphicWidth
-     graphicXOffset
-     graphicYOffset
-     rotation


Fix #321 