### PR TITLE
Fix Table Report share URL 

### DIFF
--- a/src/constants/reports/utils/index.ts
+++ b/src/constants/reports/utils/index.ts
@@ -204,9 +204,7 @@ export const getClickedMapReport = ({ feature, map, pixel, clusterSource, featur
     }
 };
 
-export const hasReportParams = (search: string = window.location.search): boolean => {
-    const params = new URLSearchParams(search);
-
+export const hasReportParams = (params: URLSearchParams): boolean => {
     return (
         params.has("status") ||
         params.has("theme") ||
@@ -219,17 +217,15 @@ export const hasReportParams = (search: string = window.location.search): boolea
     );
 };
 
-export const getReportQueryParams = () => {
-    const params = Object.fromEntries(new URLSearchParams(window.location.search));
-
+export const getReportQueryParams = (params: URLSearchParams) => {
     return {
-        status: params.status ?? "",
-        theme: params.theme ?? "",
-        author: params.author ? Number(params.author) : null,
-        departement: params.departement ?? "",
-        search: params.search ?? "",
-        sortBy: params.sortBy ?? "",
-        page: params.page ? Number(params.page) : 1,
-        limit: params.limit ? Number(params.limit) : 10,
+        status: params.get("status") ?? "",
+        theme: params.get("theme") ?? "",
+        author: params.has("author") ? Number(params.get("author")) : null,
+        departement: params.get("departement") ?? "",
+        search: params.get("search") ?? "",
+        sortBy: params.get("sortBy") ?? "",
+        page: params.has("page") ? Number(params.get("page")) : 1,
+        limit: params.has("limit") ? Number(params.get("limit")) : 10,
     };
 };

--- a/src/features/reports/ReportDrawer.tsx
+++ b/src/features/reports/ReportDrawer.tsx
@@ -190,7 +190,7 @@ const ReportDrawer = () => {
     );
 
     useEffect(() => {
-        if (hasReportParams()) {
+        if (hasReportParams(searchParams)) {
             setTableDrawerOpened(true);
         }
     }, [setTableDrawerOpened, setEditReport]);

--- a/src/features/reports/ShareReportFiltersModal.tsx
+++ b/src/features/reports/ShareReportFiltersModal.tsx
@@ -15,10 +15,10 @@ const ShareReportFiltersModal = () => {
 
     const { addAlertMessage } = useCommunityStore();
     const { shareReportFilters } = useModalStore();
-    const { syncUrlFromState } = useReportStore();
+    const { currentFilters, searchReport, sortBy, currentPage, limitPerPage, syncUrlFromState } = useReportStore();
 
     const baseUrl = useMemo(() => `${window.location.origin}${window.location.pathname}`, []);
-    const url = useMemo(() => baseUrl + syncUrlFromState(), [baseUrl, syncUrlFromState]);
+    const url = useMemo(() => baseUrl + syncUrlFromState(), [baseUrl, currentFilters, searchReport, sortBy, currentPage, limitPerPage]);
 
     const shareUrl = useMemo(() => {
         const baseParams = new URL(url).search;

--- a/src/features/reports/ShareReportFiltersModal.tsx
+++ b/src/features/reports/ShareReportFiltersModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { useTranslation } from "@/i18n";
 import { useCommunityStore, useModalStore, useReportStore } from "@/store";
 import Button from "@codegouvfr/react-dsfr/Button";
@@ -17,7 +18,9 @@ const ShareReportFiltersModal = () => {
     const { shareReportFilters } = useModalStore();
     const { currentFilters, searchReport, sortBy, currentPage, limitPerPage, syncUrlFromState } = useReportStore();
 
-    const baseUrl = useMemo(() => `${window.location.origin}${window.location.pathname}`, []);
+    const { pathname } = useLocation();
+
+    const baseUrl = useMemo(() => `${window.location.origin}${pathname}`, [pathname]);
     const url = useMemo(() => baseUrl + syncUrlFromState(), [baseUrl, currentFilters, searchReport, sortBy, currentPage, limitPerPage]);
 
     const shareUrl = useMemo(() => {

--- a/src/features/reports/table/TableReportDrawer.tsx
+++ b/src/features/reports/table/TableReportDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "@/i18n";
 import { useModalStore, useReportStore } from "@/store";
 import Button from "@codegouvfr/react-dsfr/Button";
@@ -15,20 +16,27 @@ interface Props {
 const TableReportDrawer = ({ handleCloseDrawer }: Props) => {
     const { t } = useTranslation({ TableReportDrawer });
     const [showFilter, setShowFilter] = useState(false);
+    const [searchParams, setSearchParams] = useSearchParams();
     const { shareReportFilters } = useModalStore();
-    const { reportTableWidth, setCurrentFilters, setCurrentPage, setLimitPerPage, setSortBy, setSearchReport } = useReportStore();
+    const { reportTableWidth, currentFilters, searchReport, sortBy, setCurrentFilters, setCurrentPage, setLimitPerPage, setSortBy, setSearchReport } =
+        useReportStore();
+
+    const hasActiveFilters =
+        !!currentFilters.status || !!currentFilters.theme || currentFilters.author != null || !!currentFilters.departement || !!searchReport || !!sortBy;
 
     useEffect(() => {
-        if (!hasReportParams()) {
+        if (!hasReportParams(searchParams)) {
             return;
         }
 
-        const { status, theme, author, departement, search, sortBy, page, limit } = getReportQueryParams();
+        const { status, theme, author, departement, search, sortBy, page, limit } = getReportQueryParams(searchParams);
         setCurrentFilters({ status, theme, author, departement });
         setSearchReport(search);
         setSortBy(sortBy);
         setCurrentPage(page);
         setLimitPerPage(limit);
+
+        setSearchParams(new URLSearchParams(), { replace: true });
     }, [setCurrentFilters, setSearchReport, setSortBy, setCurrentPage, setLimitPerPage]);
 
     return (
@@ -56,7 +64,7 @@ const TableReportDrawer = ({ handleCloseDrawer }: Props) => {
                 </Button>
             </div>
 
-            {(showFilter || hasReportParams()) && <FilterAndSortReport />}
+            {(showFilter || hasActiveFilters) && <FilterAndSortReport />}
             <TableReport />
             <ShareReportFiltersModal />
         </div>


### PR DESCRIPTION
Le listener n'était pas correct est donc l'url de partage n'était pas mise à jour lorsque l'on ajoutait des filtres. 
+Retirer ces paramètres de l'URL après chargement et passer par useSearchParams de react-router-dom
Issue [#183 ](https://github.com/IGNF/cartes.gouv.fr-guichet-collaboratif/issues/183#issuecomment-4934121249)