### PR TITLE
Meilleure intégration de la selection multiple. 

### DIFF
--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -478,7 +478,7 @@ export const handleCenterToFeature = (map: Map | null, feature: Feature) => {
 
     view?.animate({
         center: featureCenter,
-        zoom: featureZoom ?? view.getZoom() ?? 18,
+        zoom: (featureZoom ?? view.getZoom() ?? 18) + 1,
         duration: 400,
     });
 };

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -478,7 +478,7 @@ export const handleCenterToFeature = (map: Map | null, feature: Feature) => {
 
     view?.animate({
         center: featureCenter,
-        zoom: (featureZoom ?? view.getZoom() ?? 18) + 1,
+        zoom: Math.min(featureZoom ?? view.getZoom() ?? 19, 19),
         duration: 400,
     });
 };

--- a/src/css/review-contributions.css
+++ b/src/css/review-contributions.css
@@ -1,15 +1,35 @@
-.review-contributions {
+.review-navigation {
     display: flex;
     align-items: center;
-    gap: 4px;
-    position: absolute;
-    bottom: 8px;
-    right: 50%;
+    gap: 0.25rem;
     background-color: var(--background-default-grey);
-    border: 1px solid var(--border-default-grey);
+    border: 0.063rem solid var(--border-default-grey);
+    border-radius: 0.25rem;
     color: var(--text-default-grey);
-    padding: 4px 8px;
-    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    white-space: nowrap;
+    box-shadow: 0 0.125rem 0.375rem rgba(0, 0, 0, 0.15);
     transition: all 0.25s;
+}
+
+.review-navigation__counter {
+    min-width: 3.5rem;
+    text-align: center;
+    font-size: 0.875rem;
+}
+
+.review-contributions {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1500;
+}
+
+.review-selected-objects {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 1500;
 }

--- a/src/features/contributions/ReviewContributions.tsx
+++ b/src/features/contributions/ReviewContributions.tsx
@@ -1,7 +1,7 @@
 import { useContributionStore, useMapStore } from "@/store";
 import Button from "@codegouvfr/react-dsfr/Button";
 import type { FrIconClassName, RiIconClassName } from "@codegouvfr/react-dsfr";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { handleCenterToFeature } from "@/constants/utils";
 import { useTranslation } from "@/i18n";
 
@@ -26,17 +26,6 @@ const ReviewContributions = () => {
     const total = contrToReview.length;
     const hasContributions = total > 0;
 
-    const setCurrentContribution = useCallback(
-        (position: number) => {
-            if (contrToReview.length === 0) return;
-
-            const pos = position > contrToReview.length - 1 ? 0 : position < 0 ? contrToReview.length - 1 : position;
-
-            setClickedMapFeature(contrToReview[pos].feature);
-        },
-        [contrToReview, setClickedMapFeature]
-    );
-
     const currentIndex = useMemo(() => {
         if (!hasContributions) return 0;
 
@@ -47,24 +36,30 @@ const ReviewContributions = () => {
         return total - 1;
     }, [clickedMapFeature, contrToReview, hasContributions, total]);
 
-    useEffect(() => {
-        if (!hasContributions) return;
+    const setCurrentContribution = useCallback(
+        (position: number) => {
+            if (contrToReview.length === 0) return;
 
-        const feature = contrToReview[currentIndex]?.feature;
-        if (feature) handleCenterToFeature(map, feature);
-    }, [currentIndex, contrToReview, map, hasContributions]);
+            const pos = position > contrToReview.length - 1 ? 0 : position < 0 ? contrToReview.length - 1 : position;
+            const feature = contrToReview[pos].feature;
+
+            setClickedMapFeature(feature);
+            handleCenterToFeature(map, feature);
+        },
+        [contrToReview, map, setClickedMapFeature]
+    );
 
     const displayedPosition = hasContributions ? currentIndex + 1 : 0;
 
     return (
-        <div className="review-contributions">
+        <div className="review-contributions review-navigation">
             <ContributionButton
                 icon="ri-arrow-left-line"
                 title={t("previous")}
                 onClick={() => setCurrentContribution(currentIndex - 1)}
                 disabled={!hasContributions}
             />
-            <span>
+            <span className="review-navigation__counter">
                 Contribution {displayedPosition} / {total}
             </span>
             <ContributionButton

--- a/src/features/navigation/MainMap.tsx
+++ b/src/features/navigation/MainMap.tsx
@@ -29,6 +29,7 @@ import { APP_FOOTER_MIN_HEIGHT, APP_HEADER_HEIGHT } from "@/constants";
 import WorkingLayerLabelMap from "./controls/WorkingLayerLabelMap";
 import CustomControls from "./controls/custom-controls";
 import ReviewContributions from "../contributions/ReviewContributions";
+import ReviewSelectedObjects from "../working-layer/multiple-selection/ReviewSelectedObjects";
 import BetaBadge from "@/components/Layout/MapCommunity/BetaBadge";
 import CommunityTitle from "@/components/Layout/MapCommunity/CommunityTitle";
 import CommunityToolbar from "@/components/Layout/MapCommunity/CommunityToolbar";
@@ -42,7 +43,7 @@ export default function MainMap() {
     const { community, mapLayers } = useCommunityStore();
     const { localStorageData } = useLocalStorageStore();
     const { map, mapSwitcher, setMap } = useMapStore();
-    const { contributions, isReviewContribution } = useContributionStore();
+    const { contributions, isReviewContribution, selectedObjects } = useContributionStore();
 
     const mapControls = useGetMapControls();
 
@@ -171,6 +172,7 @@ export default function MainMap() {
 
             {map?.getAllLayers().length && <CustomControls />}
             {contributions.length > 0 && isReviewContribution && <ReviewContributions />}
+            {selectedObjects.length > 1 && !isReviewContribution && <ReviewSelectedObjects />}
         </div>
     );
 }

--- a/src/features/navigation/controls/WorkingLayerControl.tsx
+++ b/src/features/navigation/controls/WorkingLayerControl.tsx
@@ -6,6 +6,7 @@ import { useModalStore } from "@/store/useModalStore";
 import { REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import { useTranslation } from "@/i18n";
 import Select from "@codegouvfr/react-dsfr/Select";
+import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import Tooltip from "@mui/material/Tooltip";
 import Fade from "@mui/material/Fade";
 import { CommunityLayerRoleType } from "@/constants/communities/types";
@@ -152,6 +153,14 @@ const WorkingLayerControl = () => {
             pendingLayerChange.current = null;
         }
     }, [selectedObjects]);
+
+    useIsModalOpen(confirmMultipleDeselectionModal, {
+        onConceal: () => {
+            if (pendingLayerChange.current && selectedObjects.length > 0) {
+                pendingLayerChange.current = null;
+            }
+        },
+    });
 
     if (!showMapWorkingLayerSelect) return null;
 

--- a/src/features/navigation/controls/WorkingLayerControl.tsx
+++ b/src/features/navigation/controls/WorkingLayerControl.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useCallback, useMemo, memo } from "react";
+import { useEffect, useCallback, useMemo, memo, useRef } from "react";
 import { useCommunityStore, useLocalStorageStore, useMapStore } from "@/store";
+import { useContributionStore } from "@/store/useContributionStore";
+import { useModalStore } from "@/store/useModalStore";
 
 import { REPORTS_LAYER_TYPE } from "@/constants/reports/utils";
 import { useTranslation } from "@/i18n";
@@ -12,6 +14,8 @@ const WorkingLayerControl = () => {
     const { community, mapLayers, communityLayers } = useCommunityStore();
     const { map, mapSwitcher, mapWorkingLayer, showMapWorkingLayerSelect, setMapWorkingLayer, setShowMapWorkingLayerSelect } = useMapStore();
     const { localStorageData, setLocalStorage } = useLocalStorageStore();
+    const { selectedObjects } = useContributionStore();
+    const { confirmMultipleDeselectionModal } = useModalStore();
 
     const { t } = useTranslation({ WorkingLayerControl });
 
@@ -115,18 +119,39 @@ const WorkingLayerControl = () => {
         };
     }, [layerSwitcherButton, handleLayerSwitcherClick, handleLayerSwitcherMouseOver, handleLayerSwitcherMouseLeave]);
 
-    const handleWorkingLayerChange = useCallback(
+    const pendingLayerChange = useRef<(() => void) | null>(null);
+
+    const applyWorkingLayerChange = useCallback(
         (value: string) => {
             if (!community) return;
             if (localStorageData) {
                 const newLocalData = { ...localStorageData, activeLayer: value };
                 setLocalStorage(community?.name, newLocalData);
             }
-
             setMapWorkingLayer(value);
         },
         [community, localStorageData, setLocalStorage, setMapWorkingLayer]
     );
+
+    const handleWorkingLayerChange = useCallback(
+        (value: string) => {
+            if (selectedObjects.length > 1) {
+                pendingLayerChange.current = () => applyWorkingLayerChange(value);
+                confirmMultipleDeselectionModal.open();
+                return;
+            }
+
+            applyWorkingLayerChange(value);
+        },
+        [selectedObjects.length, applyWorkingLayerChange, confirmMultipleDeselectionModal]
+    );
+
+    useEffect(() => {
+        if (pendingLayerChange.current && selectedObjects.length === 0) {
+            pendingLayerChange.current();
+            pendingLayerChange.current = null;
+        }
+    }, [selectedObjects]);
 
     if (!showMapWorkingLayerSelect) return null;
 

--- a/src/features/navigation/controls/custom-controls/index.tsx
+++ b/src/features/navigation/controls/custom-controls/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import ButtonControl from "./ButtonControl";
 import { useContributionStore, useMapStore, useModalStore } from "@/store";
 import AllReportsControl from "./AllReportsControl";
@@ -18,8 +18,6 @@ import SearchObjectsModal from "@/features/working-layer/modal/searchObjects/Sea
 import ExportMapModal from "./ExportMapModal";
 import NamedPositionModal from "../NamedPositionModal";
 
-let prevClickedControl: CustomControlItem | null = null;
-
 const CustomControls = () => {
     const { clickedControl, setClickedControl, setWorkingLayerDrawerOpened, setClickedMapFeature, clickedMapFeature, workingLayerDrawerOpened } = useMapStore();
     const { selectedObjects, setSelectedObjects } = useContributionStore();
@@ -31,6 +29,7 @@ const CustomControls = () => {
 
     const interactions = useGetInteractions();
     const interactionsFuncs = useGetInteractionsFuncs(interactions);
+    const pendingControlChange = useRef<CustomControlItem | null>(null);
 
     useEffect(() => {
         const selectControl = controlsList.find((c) => c.interaction === InteractionType.SELECT);
@@ -75,7 +74,7 @@ const CustomControls = () => {
             }
 
             setClickedControl(control?.id === clickedControl?.id ? null : control);
-            prevClickedControl = null;
+            pendingControlChange.current = null;
         },
         [
             interactionsFuncs,
@@ -94,7 +93,7 @@ const CustomControls = () => {
             if (control.disabled) return;
 
             if (clickedControl?.interaction === InteractionType.SELECT && selectedObjects.length > 1) {
-                prevClickedControl = control;
+                pendingControlChange.current = control;
                 confirmMultipleDeselectionModal.open();
                 return;
             }
@@ -115,6 +114,22 @@ const CustomControls = () => {
         if (selectedObjects.length === 0) return;
         interactionsFuncs.deleteSelectedObjects(selectedObjects);
     }, [confirmMultipleObjectsActionModal, interactionsFuncs, selectedObjects]);
+
+    const handleConfirmUnSelectMultiple = () => {
+        interactions.selectInteraction.clearSelection();
+        selectedObjects.forEach((feat) => {
+            feat.unset(FEATURE_TYPE_SELECTED_PROPERTY);
+            feat.changed();
+        });
+        setSelectedObjects([]);
+        setClickedMapFeature(null);
+        confirmMultipleDeselectionModal.close();
+    };
+
+    useEffect(() => {
+        if (!pendingControlChange.current || selectedObjects.length !== 0) return;
+        onConfirm(pendingControlChange.current);
+    }, [selectedObjects.length, onConfirm]);
 
     const isEditableTarget = useCallback((target: EventTarget | null) => {
         return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || (target instanceof HTMLElement && target.isContentEditable);
@@ -189,7 +204,7 @@ const CustomControls = () => {
             </div>
             <AddOrRemoveMapControlInteraction {...interactionsFuncs} {...interactions} />
             <AddOrRemoveSnapInteraction {...interactions} />
-            <ConfirmMultipleDeselection onConfirm={() => onConfirm(prevClickedControl!)} />
+            <ConfirmMultipleDeselection onConfirm={handleConfirmUnSelectMultiple} />
             <SearchObjectsModal />
             <ConfirmMultipleObjectsActionModal action={FeatureTypeFormActionMode.DELETE} onConfirm={handleConfirmDeleteMultiple} />
             <ExportMapModal />

--- a/src/features/navigation/controls/custom-controls/index.tsx
+++ b/src/features/navigation/controls/custom-controls/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useRef } from "react";
+import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import ButtonControl from "./ButtonControl";
 import { useContributionStore, useMapStore, useModalStore } from "@/store";
 import AllReportsControl from "./AllReportsControl";
@@ -124,16 +125,23 @@ const CustomControls = () => {
         setSelectedObjects([]);
         setClickedMapFeature(null);
         confirmMultipleDeselectionModal.close();
-    };
 
-    useEffect(() => {
-        if (!pendingControlChange.current || selectedObjects.length !== 0) return;
-        onConfirm(pendingControlChange.current);
-    }, [selectedObjects.length, onConfirm]);
+        if (pendingControlChange.current) {
+            const control = pendingControlChange.current;
+            pendingControlChange.current = null;
+            onConfirm(control);
+        }
+    };
 
     const isEditableTarget = useCallback((target: EventTarget | null) => {
         return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || (target instanceof HTMLElement && target.isContentEditable);
     }, []);
+
+    useIsModalOpen(confirmMultipleDeselectionModal, {
+        onConceal: () => {
+            pendingControlChange.current = null;
+        },
+    });
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/features/navigation/controls/custom-controls/interactions/handlers/useSingleClickHandler.ts
+++ b/src/features/navigation/controls/custom-controls/interactions/handlers/useSingleClickHandler.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
+import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import { Feature, MapBrowserEvent } from "ol";
 import TileLayer from "ol/layer/Tile";
 import VectorSource from "ol/source/Vector";
@@ -256,6 +257,14 @@ export const useSingleClickHandler = (props: UseSingleClickHandlerProps) => {
         pendingSingleClickEvent.current = null;
         void handleSingleClick(pendingEvent);
     }, [selectedObjects.length, handleSingleClick]);
+
+    useIsModalOpen(confirmMultipleDeselectionModal, {
+        onConceal: () => {
+            if (pendingSingleClickEvent.current && selectedObjects.length > 0) {
+                pendingSingleClickEvent.current = null;
+            }
+        },
+    });
 
     return handleSingleClick;
 };

--- a/src/features/navigation/controls/custom-controls/interactions/handlers/useSingleClickHandler.ts
+++ b/src/features/navigation/controls/custom-controls/interactions/handlers/useSingleClickHandler.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Feature, MapBrowserEvent } from "ol";
 import TileLayer from "ol/layer/Tile";
 import VectorSource from "ol/source/Vector";
@@ -11,6 +11,8 @@ import { getClickedMapReport, getReportSketchFeatures, REPORTS_LAYER_TYPE } from
 import { getWMSFeatureInfo, getWMTSFeatureInfo } from "@/api/featureTypesData";
 import { Map } from "ol";
 import { CommunityReport } from "@/constants/reports/types";
+import { useContributionStore } from "@/store/useContributionStore";
+import { useModalStore } from "@/store/useModalStore";
 
 interface UseSingleClickHandlerProps {
     map: Map | null;
@@ -55,7 +57,11 @@ export const useSingleClickHandler = (props: UseSingleClickHandlerProps) => {
         clearHoverState,
     } = props;
 
-    return useCallback(
+    const { selectedObjects } = useContributionStore();
+    const { confirmMultipleDeselectionModal } = useModalStore();
+    const pendingSingleClickEvent = useRef<MapBrowserEvent | null>(null);
+
+    const handleSingleClick = useCallback(
         async (evt: MapBrowserEvent) => {
             if (!map || isNotClickable) return;
             if (selectedFeatures?.find((f) => f?.get("new"))) return;
@@ -138,7 +144,13 @@ export const useSingleClickHandler = (props: UseSingleClickHandlerProps) => {
                 .find((i) => i.get("type") === InteractionType.SELECT || i.get("type") === InteractionType.REMOVE);
 
             const featuresAtPixel = map?.getFeaturesAtPixel(evt.pixel);
-            if (!featuresAtPixel?.length) return;
+            if (!featuresAtPixel?.length) {
+                if (selectedObjects.length > 1) {
+                    pendingSingleClickEvent.current = evt;
+                    confirmMultipleDeselectionModal.open();
+                }
+                return;
+            }
 
             const featuresAt = getFeaturesInPixelBySource(map!, clickableSource, evt.pixel, HIT_DETECTION_TOLERENCE);
 
@@ -233,6 +245,17 @@ export const useSingleClickHandler = (props: UseSingleClickHandlerProps) => {
             handleCloseDrawer,
             handleClusterClick,
             clearHoverState,
+            selectedObjects,
+            confirmMultipleDeselectionModal,
         ]
     );
+
+    useEffect(() => {
+        if (!pendingSingleClickEvent.current || selectedObjects.length !== 0) return;
+        const pendingEvent = pendingSingleClickEvent.current;
+        pendingSingleClickEvent.current = null;
+        void handleSingleClick(pendingEvent);
+    }, [selectedObjects.length, handleSingleClick]);
+
+    return handleSingleClick;
 };

--- a/src/features/working-layer/WorkingLayerDrawer.tsx
+++ b/src/features/working-layer/WorkingLayerDrawer.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef } from "react";
 import ShowFeatureTypeForm from "./forms/ShowFeatureTypeForm";
 import EditFeatureTypeForm from "./forms/EditFeatureTypeForm";
 import { FeatureTypeMode } from "@/constants/contributions/types";
-import { FEATURE_TYPE_SELECTED_PROPERTY } from "@/constants";
+import { FEATURE_TYPE_NEW_PROPERTY, FEATURE_TYPE_SELECTED_PROPERTY } from "@/constants";
 import ConfirmMultipleDeselection from "@/features/navigation/controls/custom-controls/ConfirmMultipleDeselection";
 
 const WorkingLayerDrawer = () => {
@@ -16,9 +16,12 @@ const WorkingLayerDrawer = () => {
 
     useEffect(() => {
         if (clickedMapFeature && !workingLayerDrawerOpened && !isReviewContribution) {
+            if (clickedMapFeature.get(FEATURE_TYPE_NEW_PROPERTY)) {
+                setFeatureTypeMode(FeatureTypeMode.EDIT);
+            }
             setWorkingLayerDrawerOpened(true);
         }
-    }, [clickedMapFeature, workingLayerDrawerOpened, isReviewContribution, setWorkingLayerDrawerOpened]);
+    }, [clickedMapFeature, workingLayerDrawerOpened, isReviewContribution, setWorkingLayerDrawerOpened, setFeatureTypeMode]);
 
     const closeDrawer = useCallback(() => {
         selectedObjects.forEach((feat) => {

--- a/src/features/working-layer/multiple-selection/ReviewSelectedObjects.tsx
+++ b/src/features/working-layer/multiple-selection/ReviewSelectedObjects.tsx
@@ -3,8 +3,9 @@ import type { FrIconClassName, RiIconClassName } from "@codegouvfr/react-dsfr";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "@/i18n";
 import { useContributionStore, useMapStore } from "@/store";
+import { handleCenterToFeature } from "@/constants/utils";
 import { FEATURE_TYPE_SELECTED_PROPERTY } from "@/constants";
-import { getCenter } from "ol/extent";
+
 import type { Map } from "ol";
 import type { Feature } from "ol";
 
@@ -24,10 +25,7 @@ const panToFeature = (map: Map | null, feature: Feature) => {
     const geometry = feature.getGeometry();
     if (!geometry) return;
 
-    const extent = geometry.getExtent();
-    if (!isFinite(extent[0])) return;
-
-    map?.getView().animate({ center: getCenter(extent), duration: 300 });
+    handleCenterToFeature(map, feature);
 };
 
 const highlightOnly = (all: Feature[], focused: Feature) => {

--- a/src/features/working-layer/multiple-selection/ReviewSelectedObjects.tsx
+++ b/src/features/working-layer/multiple-selection/ReviewSelectedObjects.tsx
@@ -1,0 +1,113 @@
+import Button from "@codegouvfr/react-dsfr/Button";
+import type { FrIconClassName, RiIconClassName } from "@codegouvfr/react-dsfr";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "@/i18n";
+import { useContributionStore, useMapStore } from "@/store";
+import { FEATURE_TYPE_SELECTED_PROPERTY } from "@/constants";
+import { getCenter } from "ol/extent";
+import type { Map } from "ol";
+import type { Feature } from "ol";
+
+interface NavigationButtonProps {
+    icon: FrIconClassName | RiIconClassName;
+    title: string;
+    onClick: () => void;
+    disabled?: boolean;
+}
+
+const NavigationButton: React.FC<NavigationButtonProps> = ({ icon, title, onClick, disabled }) => (
+    <Button iconId={icon} size="small" priority="tertiary no outline" title={title} onClick={onClick} disabled={disabled} />
+);
+
+const panToFeature = (map: Map | null, feature: Feature) => {
+    // Pan to the feature's geometry center
+    const geometry = feature.getGeometry();
+    if (!geometry) return;
+
+    const extent = geometry.getExtent();
+    if (!isFinite(extent[0])) return;
+
+    map?.getView().animate({ center: getCenter(extent), duration: 300 });
+};
+
+const highlightOnly = (all: Feature[], focused: Feature) => {
+    // Highlight only the focused feature and unhighlight the others if user uses the nav bar
+    all.forEach((f) => {
+        if (f === focused) {
+            f.set(FEATURE_TYPE_SELECTED_PROPERTY, true);
+        } else {
+            f.unset(FEATURE_TYPE_SELECTED_PROPERTY);
+        }
+        f.changed();
+    });
+};
+
+const ReviewSelectedObjects = () => {
+    const { map, clickedMapFeature, setClickedMapFeature } = useMapStore();
+    const { selectedObjects, setSelectedObjects } = useContributionStore();
+
+    const { t } = useTranslation({ ReviewSelectedObjects });
+
+    const total = selectedObjects.length;
+    const hasSelectedObjects = total > 0;
+
+    const currentIndex = useMemo(() => {
+        if (total === 0) return 0;
+
+        if (clickedMapFeature) {
+            const i = selectedObjects.findIndex((f) => f === clickedMapFeature);
+            if (i !== -1) return i;
+        }
+        return 0;
+    }, [clickedMapFeature, selectedObjects, total]);
+
+    const navigateTo = useCallback(
+        // Navigate to the next or previous feature in the selectedObjects array
+        // Then update extent and highlight the other feature
+        (position: number) => {
+            if (total === 0) return;
+
+            const pos = position > total - 1 ? 0 : position < 0 ? total - 1 : position;
+            const feature = selectedObjects[pos];
+
+            highlightOnly(selectedObjects, feature);
+            setClickedMapFeature(feature);
+            panToFeature(map, feature);
+        },
+        [selectedObjects, total, map, setClickedMapFeature]
+    );
+
+    const deselectCurrent = useCallback(() => {
+        const feature = selectedObjects[currentIndex];
+        if (!feature) return;
+
+        feature.unset(FEATURE_TYPE_SELECTED_PROPERTY);
+        feature.changed();
+
+        const remaining = selectedObjects.filter((f) => f !== feature);
+        setSelectedObjects(remaining);
+
+        // Index is zero based
+        if (remaining.length > 0) {
+            const nextIndex = currentIndex >= remaining.length ? remaining.length - 1 : currentIndex;
+            setClickedMapFeature(remaining[nextIndex]);
+        } else {
+            setClickedMapFeature(null);
+        }
+    }, [selectedObjects, currentIndex, setSelectedObjects, setClickedMapFeature]);
+
+    const displayedPosition = hasSelectedObjects ? currentIndex + 1 : 0;
+
+    return (
+        <div className="review-selected-objects review-navigation">
+            <NavigationButton icon="ri-arrow-left-line" title={t("previous")} onClick={() => navigateTo(currentIndex - 1)} disabled={!hasSelectedObjects} />
+            <span className="review-navigation__counter">
+                {t("selection")} {displayedPosition} / {total}
+            </span>
+            <NavigationButton icon="ri-arrow-right-line" title={t("next")} onClick={() => navigateTo(currentIndex + 1)} disabled={!hasSelectedObjects} />
+            <NavigationButton icon="ri-close-line" title={t("deselect")} onClick={deselectCurrent} disabled={!hasSelectedObjects} />
+        </div>
+    );
+};
+
+export default ReviewSelectedObjects;

--- a/src/features/working-layer/multiple-selection/locale/ReviewSelectedObjects.locale.tsx
+++ b/src/features/working-layer/multiple-selection/locale/ReviewSelectedObjects.locale.tsx
@@ -1,0 +1,19 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const ReviewSelectedObjectsFrTranslations: Translations<"fr">["ReviewSelectedObjects"] = {
+    previous: "Objet précédent",
+    next: "Objet suivant",
+    deselect: "Désélectionner cet objet",
+    selection: "Sélection",
+};
+
+export const ReviewSelectedObjectsEnTranslations: Translations<"en">["ReviewSelectedObjects"] = {
+    previous: "Previous object",
+    next: "Next object",
+    deselect: "Unselect this object",
+    selection: "Selection",
+};
+
+const { i18n } = declareComponentKeys<"previous" | "next" | "deselect" | "selection">()("ReviewSelectedObjects");
+export type I18n = typeof i18n;

--- a/src/hooks/navigation/controls/useGetInteractionsFuncs.ts
+++ b/src/hooks/navigation/controls/useGetInteractionsFuncs.ts
@@ -65,7 +65,7 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
     const selectedObjectsRef = useRef(selectedObjects);
     useEffect(() => {
         selectedObjectsRef.current = selectedObjects;
-    });
+    }, [selectedObjects]);
 
     const selectInteractionFunc = useCallback(
         (e: SelectEvent) => {

--- a/src/hooks/navigation/controls/useGetInteractionsFuncs.ts
+++ b/src/hooks/navigation/controls/useGetInteractionsFuncs.ts
@@ -25,7 +25,7 @@ let clipboardFeature: Feature | null = null;
 const useGetInteractionsFuncs = (props: InteractionsProps) => {
     const { map, mapWorkingLayer, clickedControl, clickedMapFeature, setClickedControl, setClickedMapFeature } = useMapStore();
     const { contributions, selectedObjects, saveContribution, setIsModifying, setSelectedObjects } = useContributionStore();
-    const { searchModal, exportMapModal } = useModalStore();
+    const { searchModal, exportMapModal, confirmMultipleDeselectionModal } = useModalStore();
     const { communityLayers } = useCommunityStore();
 
     const currentCommunityLayer = useMemo(() => communityLayers?.find((l) => l?.geoservice?.layer === mapWorkingLayer), [communityLayers, mapWorkingLayer]);
@@ -62,27 +62,35 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
 
     const pasteInteractionFuncRef = useRef<((e: MapBrowserEvent) => void) | null>(null);
 
+    const selectedObjectsRef = useRef(selectedObjects);
+    useEffect(() => {
+        selectedObjectsRef.current = selectedObjects;
+    });
+
     const selectInteractionFunc = useCallback(
         (e: SelectEvent) => {
             const selectedFeatures = e.selected;
             const deselectedFeatures = e.deselected;
-            selectedFeatures.forEach((feat) => {
-                feat.set(FEATURE_TYPE_SELECTED_PROPERTY, true);
-            });
-            deselectedFeatures.forEach((feat) => {
-                feat.unset(FEATURE_TYPE_SELECTED_PROPERTY);
-            });
 
-            const newSelectedObjects = [...selectedObjects.filter((feat) => !deselectedFeatures.includes(feat)), ...selectedFeatures];
-            if (newSelectedObjects.length > 0) {
-                setClickedMapFeature(newSelectedObjects[0]);
-            } else {
-                setClickedMapFeature(null);
+            const isUserClick = !!e.mapBrowserEvent;
+            if (isUserClick && selectedFeatures.length === 0 && deselectedFeatures.length > 1) {
+                deselectedFeatures.forEach((feat) => {
+                    feat.set(FEATURE_TYPE_SELECTED_PROPERTY, true);
+                    feat.changed();
+                    selectInteraction.getFeatures().push(feat);
+                });
+                confirmMultipleDeselectionModal.open();
+                return;
             }
 
-            setSelectedObjects(newSelectedObjects);
+            selectedFeatures.forEach((feat) => feat.set(FEATURE_TYPE_SELECTED_PROPERTY, true));
+            deselectedFeatures.forEach((feat) => feat.unset(FEATURE_TYPE_SELECTED_PROPERTY));
+
+            const newSelectedObjects = selectInteraction.getFeatures().getArray();
+            setClickedMapFeature(newSelectedObjects[0] ?? null);
+            setSelectedObjects([...newSelectedObjects]);
         },
-        [selectedObjects, setSelectedObjects, setClickedMapFeature]
+        [selectInteraction, confirmMultipleDeselectionModal, setClickedMapFeature, setSelectedObjects]
     );
 
     const dragInteractionFunc = useCallback(() => {
@@ -96,7 +104,7 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
             }
         });
         const newSelectedObjects = selectInteraction.getFeatures().getArray();
-        setSelectedObjects(newSelectedObjects);
+        setSelectedObjects([...newSelectedObjects]);
         if (newSelectedObjects.length > 0) {
             setClickedMapFeature(newSelectedObjects[0]);
         }
@@ -450,7 +458,7 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
                 return;
             }
             if (control.interaction !== InteractionType.MODIFY && control.interaction !== InteractionType.TRANSLATE_OBJECT) {
-                selectedObjects.forEach((feat) => {
+                selectedObjectsRef.current.forEach((feat) => {
                     feat.unset(FEATURE_TYPE_SELECTED_PROPERTY);
                 });
             }
@@ -488,16 +496,16 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
 
                 if (control.interaction === InteractionType.MODIFY) {
                     modifyFeatures.clear();
-                    const featsToModify = selectedObjects.length > 0 ? selectedObjects : clickedMapFeature ? [clickedMapFeature] : [];
+                    const featsToModify = selectedObjectsRef.current.length > 0 ? selectedObjectsRef.current : clickedMapFeature ? [clickedMapFeature] : [];
                     featsToModify.forEach((feat) => {
                         modifyFeatures.push(feat);
                     });
                     selectInteraction.setActive(false);
                 }
 
-                if (control.interaction === InteractionType.TRANSLATE_OBJECT && selectedObjects.length > 0) {
+                if (control.interaction === InteractionType.TRANSLATE_OBJECT && selectedObjectsRef.current.length > 0) {
                     translateFeatures.clear();
-                    selectedObjects.forEach((feat) => {
+                    selectedObjectsRef.current.forEach((feat) => {
                         translateFeatures.push(feat);
                     });
                     selectInteraction.setActive(false);
@@ -512,7 +520,6 @@ const useGetInteractionsFuncs = (props: InteractionsProps) => {
             mapWorkingLayer,
             clickedControl,
             clickedMapFeature,
-            selectedObjects,
             selectInteraction,
             modifyFeatures,
             translateFeatures,

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -57,6 +57,7 @@ import { CustomControlsEnTranslations } from "@/features/navigation/controls/cus
 import { ContributionListEnTranslations } from "@/features/contributions/locale/ContributionList.locale";
 import { ContributionsConfirmResetEnTranslations } from "@/features/contributions/locale/ContributionsConfirmReset.locale";
 import { ReviewContributionsEnTranslations } from "@/features/contributions/locale/ReviewContributions.locale";
+import { ReviewSelectedObjectsEnTranslations } from "@/features/working-layer/multiple-selection/locale/ReviewSelectedObjects.locale";
 import { ConfirmSaveContributionsEnTranslations } from "@/features/contributions/locale/ConfirmSaveContributions.locale";
 import { ConfirmMultipleObjectsActionModalEnTranslations } from "@/features/working-layer/forms/locale/ConfirmMultipleObjectsActionModal.locale";
 import { ConfirmMultipleDeselectionEnTranslations } from "@/features/navigation/controls/custom-controls/locale/ConfirmMultipleDeselection.locale";
@@ -126,6 +127,7 @@ export const translations: Translations<"en"> = {
     ContributionList: ContributionListEnTranslations,
     ContributionsConfirmReset: ContributionsConfirmResetEnTranslations,
     ReviewContributions: ReviewContributionsEnTranslations,
+    ReviewSelectedObjects: ReviewSelectedObjectsEnTranslations,
     ConfirmSaveContributions: ConfirmSaveContributionsEnTranslations,
     ConfirmMultipleObjectsActionModal: ConfirmMultipleObjectsActionModalEnTranslations,
     ConfirmMultipleDeselection: ConfirmMultipleDeselectionEnTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -57,6 +57,7 @@ import { CustomControlsFrTranslations } from "@/features/navigation/controls/cus
 import { ContributionListFrTranslations } from "@/features/contributions/locale/ContributionList.locale";
 import { ContributionsConfirmResetFrTranslations } from "@/features/contributions/locale/ContributionsConfirmReset.locale";
 import { ReviewContributionsFrTranslations } from "@/features/contributions/locale/ReviewContributions.locale";
+import { ReviewSelectedObjectsFrTranslations } from "@/features/working-layer/multiple-selection/locale/ReviewSelectedObjects.locale";
 import { ConfirmSaveContributionsFrTranslations } from "@/features/contributions/locale/ConfirmSaveContributions.locale";
 import { ConfirmMultipleObjectsActionModalFrTranslations } from "@/features/working-layer/forms/locale/ConfirmMultipleObjectsActionModal.locale";
 import { ConfirmMultipleDeselectionFrTranslations } from "@/features/navigation/controls/custom-controls/locale/ConfirmMultipleDeselection.locale";
@@ -126,6 +127,7 @@ export const translations: Translations<"fr"> = {
     ContributionList: ContributionListFrTranslations,
     ContributionsConfirmReset: ContributionsConfirmResetFrTranslations,
     ReviewContributions: ReviewContributionsFrTranslations,
+    ReviewSelectedObjects: ReviewSelectedObjectsFrTranslations,
     ConfirmSaveContributions: ConfirmSaveContributionsFrTranslations,
     ConfirmMultipleObjectsActionModal: ConfirmMultipleObjectsActionModalFrTranslations,
     ConfirmMultipleDeselection: ConfirmMultipleDeselectionFrTranslations,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -26,6 +26,7 @@ export type ComponentKey =
     | import("../features/contributions/locale/ContributionList.locale").I18n
     | import("../features/contributions/locale/ContributionsConfirmReset.locale").I18n
     | import("../features/contributions/locale/ReviewContributions.locale").I18n
+    | import("../features/working-layer/multiple-selection/locale/ReviewSelectedObjects.locale").I18n
     | import("../features/contributions/locale/ConfirmSaveContributions.locale").I18n
     | import("../features/navigation/layers/locale/GetReportsLayer.locale").I18n
     | import("../features/navigation/layers/legends/locale/FeatureTypeLayerLegends.locale").I18n


### PR DESCRIPTION
On permet maintenant, de la même manière que le passage en revue des contributions, de parcourir les éléments de la sélection actuelle. 
<img width="267" height="58" alt="image" src="https://github.com/user-attachments/assets/c9b93d08-266c-42c4-8f77-9536eaa792c8" />

On propose un cordon de sécurité plus large pour vider la sélection. La modal apparaît maintenant:

- Au clic sur la carte (sans drag)
- Au changement d'outil
- Au changement de la couche de travail. Ce dernier changement permet donc de résoudre la possibilité d’édition multiple sur des éléments de deux couches différentes. 

Concerne : #300
Concerne de loin #117
