### PR TITLE
Modify Report Actions appearance

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -3,11 +3,9 @@ export const FRONT_URL = import.meta.env.VITE_FRONT_URL;
 export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
 export const API_URL = SERVER_URL + "/gcms/api";
 
-const FRONT_BASE_URL = BASE_URL + FRONT_URL;
-
-export const HOME_URL = FRONT_BASE_URL;
-export const PROFILE_URL = FRONT_BASE_URL + "/profile";
-export const PAGE_404_URL = FRONT_BASE_URL + "/page-404";
+export const HOME_URL = BASE_URL + FRONT_URL;
+export const PROFILE_URL = HOME_URL + "/profile";
+export const PAGE_404_URL = HOME_URL + "/page-404";
 
 export const LIST_COMMUNITIES_URL = SERVER_URL + "/front-office";
 export const DOWNLOAD_DOCUMENT_URL = SERVER_URL + "/document/download";
@@ -24,8 +22,8 @@ export const REPORTS_WFS_API_URL = API_URL + "/reports/wfs";
 
 export const CARTESGOUV_DISCOVER = BASE_URL + "/decouvrir";
 
-export const DASHBOARD_URL = FRONT_BASE_URL + "/tableau-de-bord";
-export const MY_ACCOUNT_URL = FRONT_BASE_URL + "/mon-compte";
+export const DASHBOARD_URL = HOME_URL + "/tableau-de-bord";
+export const MY_ACCOUNT_URL = HOME_URL + "/mon-compte";
 export const ADMIN_COMMUNITY_URL = BASE_URL + "/espace-collaboratif";
 
 // Header links (all external to community)

--- a/src/css/report-deleteShare.css
+++ b/src/css/report-deleteShare.css
@@ -8,49 +8,8 @@
     position: absolute;
     top: 0;
     right: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
     background-color: var(--background-default-grey);
-}
-
-.report-deleteShare__container {
-    position: absolute;
-    top: 0;
-    right: 40px;
-    box-shadow: 0px 2px 6px 0px var(--grey-975-75);
-    background-color: var(--background-default-grey) !important;
-}
-
-.report-deleteShare__container > button {
-    position: relative;
-    display: block;
-    background-color: var(--background-default-grey);
-    width: 100%;
-}
-
-.report-deleteShare__container .fr-btn--tertiary-no-outline {
-    --idle: var(--background-default-grey);
-    --hover: var(--background-default-grey-hover);
-    --active: var(--background-default-grey-active);
-    background-color: var(--background-default-grey);
-}
-
-.report-deleteShare__container .fr-btn--tertiary-no-outline:hover,
-.report-deleteShare__container .fr-btn--tertiary-no-outline:focus,
-.report-deleteShare__container .fr-btn--tertiary-no-outline:focus-visible {
-    background-color: var(--background-default-grey-hover) !important;
-}
-
-.report-deleteShare__container .fr-btn--tertiary-no-outline:active {
-    background-color: var(--background-default-grey-active) !important;
-}
-
-.report-deleteShare__container > button:first-child::after {
-    content: "";
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: auto;
-    width: calc(100% - 8px);
-    height: 1px;
-    background-color: var(--border-default-grey);
 }

--- a/src/features/navigation/controls/custom-controls/interactions/handlers/useSingleClickHandler.ts
+++ b/src/features/navigation/controls/custom-controls/interactions/handlers/useSingleClickHandler.ts
@@ -89,8 +89,7 @@ export const useSingleClickHandler = (props: UseSingleClickHandlerProps) => {
                         }
                     } else if (geoserviceType === "WMTS") {
                         const wmtsLayer = map.getAllLayers().find((l) => l.get("name") === mapWorkingLayer && l instanceof TileLayer) as
-                            | TileLayer<WMTS>
-                            | undefined;
+                            TileLayer<WMTS> | undefined;
                         const wmtsSource = wmtsLayer?.getSource();
 
                         if (!wmtsSource) return;

--- a/src/features/reports/DeleteShareReportComponent.tsx
+++ b/src/features/reports/DeleteShareReportComponent.tsx
@@ -1,14 +1,16 @@
 import Button from "@codegouvfr/react-dsfr/Button";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import ConfirmDeleteShareReportModal from "./ConfirmDeleteShareReportModal";
 import { useCommunityStore, useModalStore } from "@/store";
 import ShareReportModal from "./ShareReportModal";
+import { useTranslation } from "@/i18n";
 import { useGetUserProfileAPI } from "@/api/userData";
+
 interface Props {
     handleDelete: () => void;
 }
 const DeleteShareReportComponent = ({ handleDelete }: Props) => {
-    const [showActions, setShowActions] = useState<boolean>(false);
+    const { t } = useTranslation({ DeleteShareReportComponent });
     const { deleteShareReportModal, shareReport } = useModalStore();
 
     const { community } = useCommunityStore();
@@ -21,25 +23,8 @@ const DeleteShareReportComponent = ({ handleDelete }: Props) => {
 
     return (
         <div className="report-deleteShare__wrapper">
-            <Button
-                iconId="ri-more-2-line"
-                className="btn-show-actions fr-btn fr-btn--tertiary-no-outline"
-                title="Afficher les actions"
-                onClick={() => setShowActions(!showActions)}
-            />
-
-            {showActions && (
-                <div className="report-deleteShare__container">
-                    {isAdmin && (
-                        <Button priority="tertiary no outline" nativeButtonProps={deleteShareReportModal.buttonProps}>
-                            Supprimer
-                        </Button>
-                    )}
-                    <Button priority="tertiary no outline" nativeButtonProps={shareReport.buttonProps}>
-                        Partager
-                    </Button>
-                </div>
-            )}
+            {isAdmin && <Button iconId="ri-delete-bin-line" priority="secondary" title={t("delete")} nativeButtonProps={deleteShareReportModal.buttonProps} />}
+            <Button iconId="ri-share-forward-fill" priority="secondary" title={t("share")} nativeButtonProps={shareReport.buttonProps} />
 
             <ConfirmDeleteShareReportModal handleDelete={handleDelete} />
             <ShareReportModal />

--- a/src/features/reports/ShareReportModal.tsx
+++ b/src/features/reports/ShareReportModal.tsx
@@ -6,21 +6,23 @@ import Input from "@codegouvfr/react-dsfr/Input";
 import ModaleComponent from "@/components/ModaleComponent";
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import { StatusMessage } from "@/constants/communities/types";
+import { HOME_URL } from "@/constants/urls";
 
 const ShareReportModal = () => {
     const [showToast, setShowToast] = useState<boolean>(false);
 
     const { t } = useTranslation({ ShareReportModal });
 
-    const { addAlertMessage } = useCommunityStore();
+    const { addAlertMessage, community } = useCommunityStore();
     const { selectedReport } = useReportStore();
+    const communityId = community?.id;
 
     const shareInput = useMemo(() => {
-        if (!selectedReport) return "";
-        const url = new URL(window.location.href);
+        if (!selectedReport || !communityId) return "";
+        const url = new URL(`${HOME_URL}/${communityId}`, window.location.origin);
         url.searchParams.set("report", String(selectedReport.id));
         return url.toString();
-    }, [selectedReport]);
+    }, [selectedReport, communityId]);
 
     const { shareReport } = useModalStore();
 

--- a/src/features/reports/locale/DeleteShareReportComponent.locale.tsx
+++ b/src/features/reports/locale/DeleteShareReportComponent.locale.tsx
@@ -1,0 +1,15 @@
+import { Translations } from "@/i18n/types";
+import { declareComponentKeys } from "i18nifty";
+
+export const DeleteShareReportComponentFrTranslations: Translations<"fr">["DeleteShareReportComponent"] = {
+    delete: "Supprimer",
+    share: "Partager",
+};
+
+export const DeleteShareReportComponentEnTranslations: Translations<"en">["DeleteShareReportComponent"] = {
+    delete: "Delete",
+    share: "Share",
+};
+
+const { i18n } = declareComponentKeys<"delete" | "share">()("DeleteShareReportComponent");
+export type I18n = typeof i18n;

--- a/src/i18n/languages/en.tsx
+++ b/src/i18n/languages/en.tsx
@@ -21,6 +21,7 @@ import { ThemeComponentEnTranslations } from "@/features/reports/forms/locale/Th
 import { ThemeFormEnTranslations } from "@/features/reports/forms/locale/ThemeForm.locale";
 import { CenterMessageEnTranslations } from "@/features/reports/locale/CenterMessage.locale";
 import { CreateReportEnTranslations } from "@/features/reports/locale/CreateReport.locale";
+import { DeleteShareReportComponentEnTranslations } from "@/features/reports/locale/DeleteShareReportComponent.locale";
 import { EditReportEnTranslations } from "@/features/reports/locale/EditReport.locale";
 import { ReportDrawerEnTranslations } from "@/features/reports/locale/ReportDrawer.locale";
 import { ShowReportEnTranslations } from "@/features/reports/locale/ShowReport.locale";
@@ -93,6 +94,7 @@ export const translations: Translations<"en"> = {
     ThemeForm: ThemeFormEnTranslations,
     CenterMessage: CenterMessageEnTranslations,
     CreateReport: CreateReportEnTranslations,
+    DeleteShareReportComponent: DeleteShareReportComponentEnTranslations,
     EditReport: EditReportEnTranslations,
     ReportDrawer: ReportDrawerEnTranslations,
     ShowReport: ShowReportEnTranslations,

--- a/src/i18n/languages/fr.tsx
+++ b/src/i18n/languages/fr.tsx
@@ -21,6 +21,7 @@ import { ThemeComponentFrTranslations } from "@/features/reports/forms/locale/Th
 import { ThemeFormFrTranslations } from "@/features/reports/forms/locale/ThemeForm.locale";
 import { CenterMessageFrTranslations } from "@/features/reports/locale/CenterMessage.locale";
 import { CreateReportFrTranslations } from "@/features/reports/locale/CreateReport.locale";
+import { DeleteShareReportComponentFrTranslations } from "@/features/reports/locale/DeleteShareReportComponent.locale";
 import { EditReportFrTranslations } from "@/features/reports/locale/EditReport.locale";
 import { ReportDrawerFrTranslations } from "@/features/reports/locale/ReportDrawer.locale";
 import { ShowReportFrTranslations } from "@/features/reports/locale/ShowReport.locale";
@@ -93,6 +94,7 @@ export const translations: Translations<"fr"> = {
     ThemeForm: ThemeFormFrTranslations,
     CenterMessage: CenterMessageFrTranslations,
     CreateReport: CreateReportFrTranslations,
+    DeleteShareReportComponent: DeleteShareReportComponentFrTranslations,
     EditReport: EditReportFrTranslations,
     ReportDrawer: ReportDrawerFrTranslations,
     ShowReport: ShowReportFrTranslations,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -52,6 +52,7 @@ export type ComponentKey =
     | import("../features/reports/forms/locale/ThemeForm.locale").I18n
     | import("../features/reports/locale/CenterMessage.locale").I18n
     | import("../features/reports/locale/CreateReport.locale").I18n
+    | import("../features/reports/locale/DeleteShareReportComponent.locale").I18n
     | import("../features/reports/locale/EditReport.locale").I18n
     | import("../features/reports/locale/ShowReport.locale").I18n
     | import("../features/reports/locale/TableReportDrawer.locale").I18n


### PR DESCRIPTION
Address issue #332 
New appearance for the share and action buttons, which are now always visible (condition for delete is admin). 
Use the constant BASE_URL to construct the share link.
<img width="632" height="150" alt="image" src="https://github.com/user-attachments/assets/4c39993c-3ca7-4e91-a53f-a5a30671ef67" />